### PR TITLE
Use Black for auto-formatting

### DIFF
--- a/pymcfost/SED.py
+++ b/pymcfost/SED.py
@@ -3,6 +3,7 @@ import astropy.io.fits as fits
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 import numpy as np
+
 try:
     import mpl_scatter_density
 except ImportError:
@@ -40,7 +41,7 @@ class SED:
     def _read(self):
         # Read SED files
         try:
-            hdu = fits.open(self.dir+"/"+self._sed_th_file)
+            hdu = fits.open(self.dir + "/" + self._sed_th_file)
             self._sed_th = hdu[0].data
             self._wl_th = hdu[1].data
             hdu.close()
@@ -48,14 +49,14 @@ class SED:
             print('cannot open', self._sed_th_file)
 
         try:
-            hdu = fits.open(self.dir+"/"+self._sed_mc_file)
+            hdu = fits.open(self.dir + "/" + self._sed_mc_file)
             self._sed_mc = hdu[0].data
             hdu.close()
         except OSError:
             print('cannot open', self._sed_mc_file)
 
         try:
-            hdu = fits.open(self.dir+"/"+self._sed_rt_file)
+            hdu = fits.open(self.dir + "/" + self._sed_rt_file)
             self.sed = hdu[0].data
             self.wl = hdu[1].data
             hdu.close()
@@ -64,14 +65,15 @@ class SED:
 
         # Read temperature file
         try:
-            hdu = fits.open(self.dir+"/"+self._temperature_file)
+            hdu = fits.open(self.dir + "/" + self._temperature_file)
             self.T = hdu[0].data
             hdu.close()
         except OSError:
             print('cannot open', self._temperature_file)
 
-    def plot(self, i, iaz=0, MC=False, contrib=False, Av=0, Rv=3.1,
-             color="black", **kwargs):
+    def plot(
+        self, i, iaz=0, MC=False, contrib=False, Av=0, Rv=3.1, color="black", **kwargs
+    ):
 
         # extinction
         if Av > 0:
@@ -80,27 +82,35 @@ class SED:
         else:
             redenning = 1.0
 
-        if (MC):
-            sed = self._sed_mc[:,iaz,i,:] * redenning
+        if MC:
+            sed = self._sed_mc[:, iaz, i, :] * redenning
         else:
-            sed = self.sed[:,iaz,i,:] * redenning
+            sed = self.sed[:, iaz, i, :] * redenning
 
-        plt.loglog(self.wl, sed[0,:], color=color, **kwargs)
+        plt.loglog(self.wl, sed[0, :], color=color, **kwargs)
         plt.xlabel("$\lambda$ [$\mu$m]")
         plt.ylabel("$\lambda$.F$_{\lambda}$ [W.m$^{-2}$]")
 
         if contrib:
             n_type_flux = sed.shape[0]
-            if n_type_flux in [5,8,9]:
+            if n_type_flux in [5, 8, 9]:
                 if n_type_flux > 5:
                     n_pola = 4
                 else:
                     n_pola = 1
                 linewidth = 0.5
-                plt.loglog(self.wl, sed[n_pola,:],   linewidth=linewidth, color="magenta")
-                plt.loglog(self.wl, sed[n_pola+1,:], linewidth=linewidth, color="blue")
-                plt.loglog(self.wl, sed[n_pola+2,:], linewidth=linewidth, color="red")
-                plt.loglog(self.wl, sed[n_pola+3,:], linewidth=linewidth, color="green")
+                plt.loglog(
+                    self.wl, sed[n_pola, :], linewidth=linewidth, color="magenta"
+                )
+                plt.loglog(
+                    self.wl, sed[n_pola + 1, :], linewidth=linewidth, color="blue"
+                )
+                plt.loglog(
+                    self.wl, sed[n_pola + 2, :], linewidth=linewidth, color="red"
+                )
+                plt.loglog(
+                    self.wl, sed[n_pola + 3, :], linewidth=linewidth, color="green"
+                )
             else:
                 ValueError("There is no contribution data")
 
@@ -108,9 +118,8 @@ class SED:
         # Compares the SED from step 1 and step 2 to check if energy is properly conserved
         current_fig = plt.gcf().number
         plt.figure(20)
-        plt.loglog(self._wl_th, np.sum(self._sed_th[0,:,:],axis=0), color="black")
-        plt.loglog(self.wl, np.sum(self._sed_mc[0,0,:,:],
-                                   axis=0), color="red")
+        plt.loglog(self._wl_th, np.sum(self._sed_th[0, :, :], axis=0), color="black")
+        plt.loglog(self.wl, np.sum(self._sed_mc[0, 0, :, :], axis=0), color="red")
         plt.figure(current_fig)
 
     def plot_T(self, iaz=0, log=False, Tmin=None, Tmax=None):
@@ -129,64 +138,76 @@ class SED:
                 self.disc = Disc(self.basedir)
                 grid = self.disc.grid
             except AttributeError:
-                print("Cannot read grid in "+self.basedir)
+                print("Cannot read grid in " + self.basedir)
 
         plt.cla()
 
-        if (grid.ndim > 2):
+        if grid.ndim > 2:
             Voronoi = False
 
-            r = grid[0,iaz,:,:]
-            z = grid[1,iaz,:,:]
-            if (self.T.ndim > 2):
-                T = self.T[iaz,:,:]
+            r = grid[0, iaz, :, :]
+            z = grid[1, iaz, :, :]
+            if self.T.ndim > 2:
+                T = self.T[iaz, :, :]
             else:
-                T = self.T[:,:]
+                T = self.T[:, :]
         else:
             Voronoi = True
             T = self.T
-            r = np.sqrt(grid[0,:]**2 + grid[1,:]**2)
-            ou = (r > 1e-6)  # Removing star
+            r = np.sqrt(grid[0, :] ** 2 + grid[1, :] ** 2)
+            ou = r > 1e-6  # Removing star
             T = T[ou]
             r = r[ou]
-            z = grid[2,ou]
+            z = grid[2, ou]
 
-        if (Tmin is None):
+        if Tmin is None:
             Tmin = T.min()
-        if (Tmax is None):
+        if Tmax is None:
             Tmax = T.max()
 
-        if (log):
-            if (Voronoi):
-                #plt.scatter(r,z/r,c=T,s=0.1, norm=colors.LogNorm(vmin=Tmin, vmax=Tmax))
+        if log:
+            if Voronoi:
+                # plt.scatter(r,z/r,c=T,s=0.1, norm=colors.LogNorm(vmin=Tmin, vmax=Tmax))
                 fig = plt.gcf()
                 ax = fig.add_subplot(1, 1, 1, projection='scatter_density')
-                density = ax.scatter_density(r, z/r, c=T, cmap=plt.cm.RdYlBu_r, dpi=100, norm=colors.LogNorm(vmin=Tmin, vmax=Tmax))
-                fig.colorbar(density, label = "T [K]")
+                density = ax.scatter_density(
+                    r,
+                    z / r,
+                    c=T,
+                    cmap=plt.cm.RdYlBu_r,
+                    dpi=100,
+                    norm=colors.LogNorm(vmin=Tmin, vmax=Tmax),
+                )
+                fig.colorbar(density, label="T [K]")
             else:
-                plt.pcolormesh(r,z/r,T, norm=colors.LogNorm(vmin=Tmin, vmax=Tmax))
+                plt.pcolormesh(r, z / r, T, norm=colors.LogNorm(vmin=Tmin, vmax=Tmax))
                 cb = plt.colorbar()
                 cb.set_label('T [K]')
             plt.xscale('log')
             plt.xlabel("r [au]")
             plt.ylabel("z/r")
         else:
-            if (Voronoi):
-                #plt.scatter(r,z,c=T,s=0.1, norm=colors.LogNorm(vmin=Tmin, vmax=Tmax))
+            if Voronoi:
+                # plt.scatter(r,z,c=T,s=0.1, norm=colors.LogNorm(vmin=Tmin, vmax=Tmax))
                 fig = plt.gcf()
                 ax = fig.add_subplot(1, 1, 1, projection='scatter_density')
-                density = ax.scatter_density(r, z, c=T, cmap=plt.cm.RdYlBu_r, dpi=100, norm=colors.LogNorm(vmin=Tmin, vmax=Tmax))
-                fig.colorbar(density, label = "T [K]")
+                density = ax.scatter_density(
+                    r,
+                    z,
+                    c=T,
+                    cmap=plt.cm.RdYlBu_r,
+                    dpi=100,
+                    norm=colors.LogNorm(vmin=Tmin, vmax=Tmax),
+                )
+                fig.colorbar(density, label="T [K]")
             else:
-                plt.pcolormesh(r,z,T, norm=colors.LogNorm(vmin=Tmin, vmax=Tmax))
+                plt.pcolormesh(r, z, T, norm=colors.LogNorm(vmin=Tmin, vmax=Tmax))
                 cb = plt.colorbar()
                 cb.set_label('T [K]')
             plt.xlabel("r [au]")
             plt.ylabel("z [au]")
 
-
-
-    def plot_Tz(self, r=100., dr=5., log=False, **kwargs):
+    def plot_Tz(self, r=100.0, dr=5.0, log=False, **kwargs):
 
         try:
             grid = self.disc.grid
@@ -196,23 +217,23 @@ class SED:
                 self.disc = Disc(self.basedir)
                 grid = self.disc.grid
             except AttributeError:
-                print("Cannot read grid in "+self.basedir)
+                print("Cannot read grid in " + self.basedir)
 
         T = self.T
-        if (grid.ndim > 2):
+        if grid.ndim > 2:
             Voronoi = False
-            r_mcfost = grid[0,0,:,:]
-            z_mcfost = grid[1,0,:,:]
+            r_mcfost = grid[0, 0, :, :]
+            z_mcfost = grid[1, 0, :, :]
         else:
             Voronoi = True
-            r_mcfost = np.sqrt(grid[0,:]**2 + grid[1,:]**2)
-            ou = (r_mcfost > 1e-6)  # Removing star
+            r_mcfost = np.sqrt(grid[0, :] ** 2 + grid[1, :] ** 2)
+            ou = r_mcfost > 1e-6  # Removing star
             T = T[ou]
             r_mcfost = r_mcfost[ou]
-            z_mcfost = grid[2,ou]
+            z_mcfost = grid[2, ou]
 
         # Selecting data points
-        ou = (r_mcfost > r-dr) & (r_mcfost < r+dr)
+        ou = (r_mcfost > r - dr) & (r_mcfost < r + dr)
 
         # If we have cylindrical grid, we search for closest grid point
         # Todo
@@ -220,10 +241,9 @@ class SED:
         z_mcfost = z_mcfost[ou]
         T = T[ou]
 
-        plt.plot(z_mcfost,T,"o",**kwargs)
+        plt.plot(z_mcfost, T, "o", **kwargs)
         plt.xlabel("z [au]")
         plt.ylabel("T [K]")
-
 
     def plot_Tr(self, h_r=0.05, log=True, symbol=None, **kwargs):
 
@@ -235,23 +255,23 @@ class SED:
                 self.disc = Disc(self.basedir)
                 grid = self.disc.grid
             except AttributeError:
-                print("Cannot read grid in "+self.basedir)
+                print("Cannot read grid in " + self.basedir)
 
         T = self.T
-        if (grid.ndim > 2):
+        if grid.ndim > 2:
             Voronoi = False
-            r_mcfost = grid[0,0,:,:]
-            z_mcfost = grid[1,0,:,:]
+            r_mcfost = grid[0, 0, :, :]
+            z_mcfost = grid[1, 0, :, :]
         else:
             Voronoi = True
-            r_mcfost = np.sqrt(grid[0,:]**2 + grid[1,:]**2)
-            ou = (r_mcfost > 1e-6)  # Removing star
+            r_mcfost = np.sqrt(grid[0, :] ** 2 + grid[1, :] ** 2)
+            ou = r_mcfost > 1e-6  # Removing star
             T = T[ou]
             r_mcfost = r_mcfost[ou]
-            z_mcfost = grid[2,ou]
+            z_mcfost = grid[2, ou]
 
         # Selecting data points
-        ou = (abs(z_mcfost)/r_mcfost < h_r)
+        ou = abs(z_mcfost) / r_mcfost < h_r
 
         # If we have cylindrical grid, we search for closest grid point
         # Todo
@@ -259,9 +279,9 @@ class SED:
         r_mcfost = r_mcfost[ou]
         T = T[ou]
 
-        if (log):
-            plt.loglog(r_mcfost,T,"o",linewidth=0.2,**kwargs)
+        if log:
+            plt.loglog(r_mcfost, T, "o", linewidth=0.2, **kwargs)
         else:
-            plt.plot(r_mcfost,T,"o",linewidth=0.2,**kwargs)
+            plt.plot(r_mcfost, T, "o", linewidth=0.2, **kwargs)
         plt.xlabel("z [au]")
         plt.ylabel("T [K]")

--- a/pymcfost/disc_structure.py
+++ b/pymcfost/disc_structure.py
@@ -8,12 +8,11 @@ from .parameters import Params, find_parameter_file
 
 
 class Disc:
-
     def __init__(self, dir=None, **kwargs):
         # Correct path if needed
         dir = os.path.normpath(os.path.expanduser(dir))
-        if (dir[-9:] != "data_disk"):
-            dir = os.path.join(dir,"data_disk")
+        if dir[-9:] != "data_disk":
+            dir = os.path.join(dir, "data_disk")
         self.dir = dir
 
         # Search for parameter file
@@ -28,7 +27,7 @@ class Disc:
     def _read(self):
         # Read grid file
         try:
-            hdu = fits.open(self.dir+"/grid.fits.gz")
+            hdu = fits.open(self.dir + "/grid.fits.gz")
             self.grid = hdu[0].data
             hdu.close()
         except OSError:
@@ -36,7 +35,7 @@ class Disc:
 
         # Read gas density file
         try:
-            hdu = fits.open(self.dir+"/gas_density.fits.gz")
+            hdu = fits.open(self.dir + "/gas_density.fits.gz")
             self.gas_density = hdu[0].data
             hdu.close()
         except OSError:
@@ -44,26 +43,27 @@ class Disc:
 
         # Read volume file
         try:
-            hdu = fits.open(self.dir+"/volume.fits.gz")
+            hdu = fits.open(self.dir + "/volume.fits.gz")
             self.volume = hdu[0].data
             hdu.close()
         except OSError:
             print('cannot open volume.fits.gz')
 
-
     def r(self):
-        if (self.grid.ndim > 2):
-            return self.grid[0,:,:,:]
+        if self.grid.ndim > 2:
+            return self.grid[0, :, :, :]
         else:
-            return np.sqrt(self.grid[0,:]**2 + self.grid[1,:]**2)
+            return np.sqrt(self.grid[0, :] ** 2 + self.grid[1, :] ** 2)
 
     def z(self):
-        if (self.grid.ndim > 2):
-            return self.grid[1,:,:,:]
+        if self.grid.ndim > 2:
+            return self.grid[1, :, :, :]
         else:
-            return self.grid[2,:]
+            return self.grid[2, :]
 
-    def add_spiral(self, a=30, sigma=10, f=1, theta0=0, rmin=None, rmax=None, n_az=None):
+    def add_spiral(
+        self, a=30, sigma=10, f=1, theta0=0, rmin=None, rmax=None, n_az=None
+    ):
         """ Add a geometrucal spiral on a 2D (or 3D) mcfost density grid
         and return a 3D array which can be directly written as a fits
         file for mcfost to read
@@ -73,27 +73,27 @@ class Disc:
         the spiral has a Gaussin profil in (x,y) with sigma given in au
         """
 
-        if (self.grid.ndim <= 2):
+        if self.grid.ndim <= 2:
             ValueError("Can only add a spiral on a cylindrical or spherical grid")
 
-        if (n_az is None):
+        if n_az is None:
             n_az = self.grid.shape[1]
-        phi = np.linspace(0,2*np.pi,n_az,endpoint=False)
+        phi = np.linspace(0, 2 * np.pi, n_az, endpoint=False)
 
-        r = self.grid[0,0,0,:]
+        r = self.grid[0, 0, 0, :]
 
         if rmin is None:
             rmin = r.min()
         if rmax is None:
             rmax = r.max()
 
-        x = r[np.newaxis,:] * np.cos(phi[:,np.newaxis])
-        y = r[np.newaxis,:] * np.sin(phi[:,np.newaxis])
+        x = r[np.newaxis, :] * np.cos(phi[:, np.newaxis])
+        y = r[np.newaxis, :] * np.sin(phi[:, np.newaxis])
 
         # Just to test
-        #x = np.linspace(-100,100,500)
-        #x, y = np.meshgrid(x,x)
-        #r = np.sqrt(x**2 + y**2) # we recalcule in preparation for other types of grid
+        # x = np.linspace(-100,100,500)
+        # x, y = np.meshgrid(x,x)
+        # r = np.sqrt(x**2 + y**2) # we recalcule in preparation for other types of grid
 
         # rc=50, hc=0.15, alpha=1.5, beta=0.25
         # theta_c = 0.
@@ -101,8 +101,8 @@ class Disc:
         #        ((r/rc)**(1+beta) * (1/(1+beta) - 1/(1-alpha + beta) * (r/rc)**(-alpha)) \
         #         - 1/(1+beta) - 1/(1-alpha + beta))
 
-        r_spiral = np.geomspace(rmin,rmax,num=5000)
-        theta = r_spiral/a + theta0
+        r_spiral = np.geomspace(rmin, rmax, num=5000)
+        theta = r_spiral / a + theta0
 
         x_spiral = r_spiral * np.cos(theta)
         y_spiral = r_spiral * np.sin(theta)
@@ -110,13 +110,13 @@ class Disc:
         correct = np.ones(x.shape)
 
         # This is really badly implemented, but fast enough that we don't care
-        sigma2 = sigma**2
+        sigma2 = sigma ** 2
         for i in range(x.shape[0]):
             for j in range(x.shape[1]):
-                d2 = np.min( (x_spiral - x[i,j])**2 + (y_spiral - y[i,j])**2 )
-                correct[i,j] += f * np.exp(-0.5 * d2/sigma2)
+                d2 = np.min((x_spiral - x[i, j]) ** 2 + (y_spiral - y[i, j]) ** 2)
+                correct[i, j] += f * np.exp(-0.5 * d2 / sigma2)
 
         triang = tri.Triangulation(x.flatten(), y.flatten())
         plt.tripcolor(triang, correct.flatten(), shading='flat')
 
-        return self.gas_density[np.newaxis,:,:] * correct[:,np.newaxis,:]
+        return self.gas_density[np.newaxis, :, :] * correct[:, np.newaxis, :]

--- a/pymcfost/fargo2mcfost.py
+++ b/pymcfost/fargo2mcfost.py
@@ -6,92 +6,110 @@ import subprocess
 from .parameters import Params
 from .disc_structure import Disc
 
-def fargo2mcfost(data_dir,dump_number,nz=5,mcfost_ref_file="/Users/cpinte/mcfost/src/ref3.0_3D.para",mcfost_filename = "mcfost_FARGO.para",fitsname=None):
 
-    #--- Need to read fargo .par file here, hard-coded for now
-    #--- TODO : read Frame == C ou F  to detect is planet is rotating or not
-    #--- if C : add keplrian velocity of planet
+def fargo2mcfost(
+    data_dir,
+    dump_number,
+    nz=5,
+    mcfost_ref_file="/Users/cpinte/mcfost/src/ref3.0_3D.para",
+    mcfost_filename="mcfost_FARGO.para",
+    fitsname=None,
+):
+
+    # --- Need to read fargo .par file here, hard-coded for now
+    # --- TODO : read Frame == C ou F  to detect is planet is rotating or not
+    # --- if C : add keplrian velocity of planet
     # TODO : we need to read FACTORUNITMASS & FACTIORUNITLENGHT
-    #-- MM
+    # -- MM
     Runit = 10.0
     Munit = 1.0  # star always has a mass == 1
     Frame = "C"
     Rmin = 4
     Rmax = 25
 
+    # -- TODO : easiest if probably to read Rmin, Rmax, Nrad, Nsec here too
+    # -- then we can skip dims.dat
 
-    #-- TODO : easiest if probably to read Rmin, Rmax, Nrad, Nsec here too
-    #-- then we can skip dims.dat
-
-
-    #--- Load dims.dat
+    # --- Load dims.dat
     # This is an output file which contains for example the number of grid points
     try:
-        dims = np.loadtxt(data_dir+'/dims.dat')
+        dims = np.loadtxt(data_dir + '/dims.dat')
     except:
         sys.exit('Could not load dims.dat')
-    N_t       = int(dims[5])                                 # Number of outputs
-    N_R       = int(dims[6])                                 # Number of radial gridpoint
-    N_theta   = int(dims[7])                                 # Number of angular grid points
+    N_t = int(dims[5])  # Number of outputs
+    N_R = int(dims[6])  # Number of radial gridpoint
+    N_theta = int(dims[7])  # Number of angular grid points
 
-    #--- Load planet0.dat
+    # --- Load planet0.dat
     try:
-        planet0 = np.loadtxt(data_dir+'/planet0.dat')
+        planet0 = np.loadtxt(data_dir + '/planet0.dat')
     except:
         sys.exit('Could not load planet0.dat!')
     dummy_i = -1
 
-    #-- Todo : I have have no idea what those lines are doing
-    #-- the test planet0[i, 0] == dummy_i is always false
+    # -- Todo : I have have no idea what those lines are doing
+    # -- the test planet0[i, 0] == dummy_i is always false
     for i in range(planet0.shape[0]):
-        if(planet0[i, 0] == dummy_i):
-            planet0[i-1:planet0.shape[0]-1, :] = planet0[i:,:]
+        if planet0[i, 0] == dummy_i:
+            planet0[i - 1 : planet0.shape[0] - 1, :] = planet0[i:, :]
         dummy_i = planet0[i, 0]
 
     # Cartesian coordinates of the planet
-    planet_x = planet0[dump_number,1] * u.AU
-    planet_y = planet0[dump_number,2] * u.AU
+    planet_x = planet0[dump_number, 1] * u.AU
+    planet_y = planet0[dump_number, 2] * u.AU
     # Transform to polar coordinates
-    planet_R     = np.sqrt( planet_x**2 + planet_y**2 )
-    planet_theta = np.arctan2( planet_y, planet_x )
+    planet_R = np.sqrt(planet_x ** 2 + planet_y ** 2)
+    planet_theta = np.arctan2(planet_y, planet_x)
 
-    #--- physical ctes
-    grav =  39.4862194 # (au^3) / (solar mass * (yr^2))
-    Timeunit = np.sqrt(Runit**3.0/(grav*Munit)) # yr
-    Lumunit =   Munit*Runit*Runit/(Timeunit*Timeunit*Timeunit) #  Msun*au^2*yr^-3
-    Lsun = 2.7e-4 # Msun au^2/yr^3
-    Lestrella =  1.0*(Lsun/Lumunit) #
-    Rgas = 3.67e-4 # //au^2/(yr^2 K)   R =0.000183508935; // R = 4124 [J/kg/K] = 0.000183508935 (au^2) / ((year^2) * kelvin)
-    Tempunit = 2.35*(grav*Munit/(Rgas*Runit)) # Kelvin
-    densINcgs = 8888035.76 #1 Msun/au^2 = 8888035.76 grams / (cm^2)
-    DensUnit = densINcgs * Munit / Runit**2.0  # grams / (cm^2)
-    QplusUnit = 1.6e13 #erg/s/cm^2
-    vel_unit = Runit/ Timeunit * 474057.172  #1 au/yr = 474 057.172 cm/s
+    # --- physical ctes
+    grav = 39.4862194  # (au^3) / (solar mass * (yr^2))
+    Timeunit = np.sqrt(Runit ** 3.0 / (grav * Munit))  # yr
+    Lumunit = (
+        Munit * Runit * Runit / (Timeunit * Timeunit * Timeunit)
+    )  #  Msun*au^2*yr^-3
+    Lsun = 2.7e-4  # Msun au^2/yr^3
+    Lestrella = 1.0 * (Lsun / Lumunit)  #
+    Rgas = (
+        3.67e-4
+    )  # //au^2/(yr^2 K)   R =0.000183508935; // R = 4124 [J/kg/K] = 0.000183508935 (au^2) / ((year^2) * kelvin)
+    Tempunit = 2.35 * (grav * Munit / (Rgas * Runit))  # Kelvin
+    densINcgs = 8888035.76  # 1 Msun/au^2 = 8888035.76 grams / (cm^2)
+    DensUnit = densINcgs * Munit / Runit ** 2.0  # grams / (cm^2)
+    QplusUnit = 1.6e13  # erg/s/cm^2
+    vel_unit = Runit / Timeunit * 474057.172  # 1 au/yr = 474 057.172 cm/s
 
-    #--- Does the planet rotate
-    if (Frame == "C"):
-        vtheta_planet = np.sqrt(grav*Munit/planet_R)*vel_unit
+    # --- Does the planet rotate
+    if Frame == "C":
+        vtheta_planet = np.sqrt(grav * Munit / planet_R) * vel_unit
     else:
         vtheta_planet = 0.0
 
-    #--- Reading data
-    rho = np.fromfile(data_dir + "/gasdens{0:d}.dat".format(dump_number),dtype='float64')
-    temp = np.fromfile(data_dir + "/gasTemperature{0:d}.dat".format(dump_number),dtype='float64')
-    vrad = np.fromfile(data_dir + "/gasvrad{0:d}.dat".format(dump_number),dtype='float64')
-    vtheta = np.fromfile(data_dir + "/gasvtheta{0:d}.dat".format(dump_number),dtype='float64')
+    # --- Reading data
+    rho = np.fromfile(
+        data_dir + "/gasdens{0:d}.dat".format(dump_number), dtype='float64'
+    )
+    temp = np.fromfile(
+        data_dir + "/gasTemperature{0:d}.dat".format(dump_number), dtype='float64'
+    )
+    vrad = np.fromfile(
+        data_dir + "/gasvrad{0:d}.dat".format(dump_number), dtype='float64'
+    )
+    vtheta = np.fromfile(
+        data_dir + "/gasvtheta{0:d}.dat".format(dump_number), dtype='float64'
+    )
 
-    #--- Correct units + add velocity offset if needed
+    # --- Correct units + add velocity offset if needed
     rho_cgs = DensUnit * rho  # gr/cm^2
-    temp_cgs = Tempunit*temp   # Kelvin
-    vrad_cgs = vel_unit* vrad
-    vtheta_cgs = vel_unit* vtheta + vtheta_planet.value
+    temp_cgs = Tempunit * temp  # Kelvin
+    vrad_cgs = vel_unit * vrad
+    vtheta_cgs = vel_unit * vtheta + vtheta_planet.value
 
-    #--- reshape
-    Rho = DensUnit*rho.reshape(N_R,N_theta)
-    Temp = Tempunit*temp.reshape(N_R,N_theta)
+    # --- reshape
+    Rho = DensUnit * rho.reshape(N_R, N_theta)
+    Temp = Tempunit * temp.reshape(N_R, N_theta)
 
-    #--- mcfost : updating values from FARGO
-    #--- Setting up a parameter file and creating the corresponding grid
+    # --- mcfost : updating values from FARGO
+    # --- Setting up a parameter file and creating the corresponding grid
     P = Params(mcfost_ref_file)
     P.grid.n_rad = N_R
     P.grid.n_rad_in = 1
@@ -99,58 +117,59 @@ def fargo2mcfost(data_dir,dump_number,nz=5,mcfost_ref_file="/Users/cpinte/mcfost
     P.grid.n_az = N_theta
 
     P.zones[0].Rin = Rmin
-    P.zones[0].edge = 0.
+    P.zones[0].edge = 0.0
     P.zones[0].Rout = Rmax
-    P.zones[0].Rc = 0.
+    P.zones[0].Rc = 0.0
 
-    #--- TODO : compute spectral type for given stellar mass
-    #-- CP
+    # --- TODO : compute spectral type for given stellar mass
+    # -- CP
 
-    #-- Turn off symmetries
+    # -- Turn off symmetries
     P.simu.image_symmetry = False
     P.simu.central_symmetry = False
     P.simu.axial_symmetry = False
 
-    #-- TODO : compute gas mass properly and put it in mcfost_FARGO.para
-    #-- MM
+    # -- TODO : compute gas mass properly and put it in mcfost_FARGO.para
+    # -- MM
 
-    #-- Write new parameter file
+    # -- Write new parameter file
     P.writeto(mcfost_filename)
 
-    #--- Running mcfost to create the grid
-    subprocess.call(["rm","-rf","data_disk","data_disk_old"])
-    result = subprocess.call(["mcfost",mcfost_filename,"-disk_struct"])
+    # --- Running mcfost to create the grid
+    subprocess.call(["rm", "-rf", "data_disk", "data_disk_old"])
+    result = subprocess.call(["mcfost", mcfost_filename, "-disk_struct"])
 
-    #--- Reading mcfost grid
+    # --- Reading mcfost grid
     mcfost_disc = Disc("./")
 
-    #--- print the mcfost radial grid to check that it is the same as FARGO's
+    # --- print the mcfost radial grid to check that it is the same as FARGO's
     print("MCFOST radii=")
-    print(mcfost_disc.r()[0,0,:])
+    print(mcfost_disc.r()[0, 0, :])
 
     # -- same dimension order as FARGO
     mcfost_z = mcfost_disc.z()
 
-    #--taking only half the grid (+z)
-    mcfost_z = mcfost_z[:,nz+1:,:]
-    mcfost_z = mcfost_z.transpose() # dims are now, r, z, theta
+    # --taking only half the grid (+z)
+    mcfost_z = mcfost_z[:, nz + 1 :, :]
+    mcfost_z = mcfost_z.transpose()  # dims are now, r, z, theta
 
-    #-- TODO: defining H [au]
-    #--- MM
-    h = 0.05 * mcfost_disc.r()[:,0,:].transpose()
+    # -- TODO: defining H [au]
+    # --- MM
+    h = 0.05 * mcfost_disc.r()[:, 0, :].transpose()
 
-    #-- computing the 3D density structure for mcfost
-    rho_mcfost = Rho[:,np.newaxis,:] * np.exp( - 0.5 * (mcfost_z/h[:,np.newaxis,:]))
+    # -- computing the 3D density structure for mcfost
+    rho_mcfost = Rho[:, np.newaxis, :] * np.exp(-0.5 * (mcfost_z / h[:, np.newaxis, :]))
 
-    #--- Write a fits file for mcfost
+    # --- Write a fits file for mcfost
     if fitsname is not None:
-        print("Writing ",fitsname," to disk")
-        fits.writeto(fitsname,rho_mcfost.transpose(),overwrite=True)
-        #--- TODO : add velocity : CP
+        print("Writing ", fitsname, " to disk")
+        fits.writeto(fitsname, rho_mcfost.transpose(), overwrite=True)
+        # --- TODO : add velocity : CP
     else:
         print("Fits file for mcfost was not created")
 
     return rho_mcfost
+
 
 # Run with :
 # import pymcfost as mcfost

--- a/pymcfost/image.py
+++ b/pymcfost/image.py
@@ -12,7 +12,15 @@ import numpy as np
 import scipy.constants as sc
 
 from .parameters import Params, find_parameter_file
-from .utils import bin_image, FWHM_to_sigma, default_cmap, Wm2_to_Jy, Wm2_to_Tb, Jy_to_Tb
+from .utils import (
+    bin_image,
+    FWHM_to_sigma,
+    default_cmap,
+    Wm2_to_Jy,
+    Wm2_to_Tb,
+    Jy_to_Tb,
+)
+
 
 class Image:
 
@@ -36,29 +44,57 @@ class Image:
     def _read(self):
         # Read ray-traced image
         try:
-            hdu = fits.open(self.dir+"/"+self._RT_file)
+            hdu = fits.open(self.dir + "/" + self._RT_file)
             self.image = hdu[0].data
             # Read a few keywords in header
-            self.pixelscale = hdu[0].header['CDELT2'] * 3600. # arcsec
-            self.unit       = hdu[0].header['BUNIT']
-            self.wl         = hdu[0].header['WAVE'] # micron
-            self.freq       = sc.c/(self.wl*1e-6)
-            self.cx         = hdu[0].header['CRPIX1']
-            self.cy         = hdu[0].header['CRPIX2']
-            self.nx         = hdu[0].header['NAXIS1']
-            self.ny         = hdu[0].header['NAXIS2']
-            self.is_casa    = (self.unit == "JY/PIXEL")
+            self.pixelscale = hdu[0].header['CDELT2'] * 3600.0  # arcsec
+            self.unit = hdu[0].header['BUNIT']
+            self.wl = hdu[0].header['WAVE']  # micron
+            self.freq = sc.c / (self.wl * 1e-6)
+            self.cx = hdu[0].header['CRPIX1']
+            self.cy = hdu[0].header['CRPIX2']
+            self.nx = hdu[0].header['NAXIS1']
+            self.ny = hdu[0].header['NAXIS2']
+            self.is_casa = self.unit == "JY/PIXEL"
             hdu.close()
         except OSError:
             print('cannot open', self._RT_file)
 
-    def plot(self,i=0,iaz=0,vmin=None,vmax=None,dynamic_range=1e6,fpeak=None,
-             axes_unit='arcsec',colorbar=True,type='I',scale=None,
-             pola_vector=False,vector_color="white",nbin=5,psf_FWHM=None,
-             bmaj=None,bmin=None,bpa=None,plot_beam=None,conv_method=None,
-             mask=None,cmap=None,ax=None,no_xlabel=False,no_ylabel=False,
-             no_xticks=False,no_yticks=False,title=None,limit=None,limits=None,
-             coronagraph=None,clear=False,Tb=False):
+    def plot(
+        self,
+        i=0,
+        iaz=0,
+        vmin=None,
+        vmax=None,
+        dynamic_range=1e6,
+        fpeak=None,
+        axes_unit='arcsec',
+        colorbar=True,
+        type='I',
+        scale=None,
+        pola_vector=False,
+        vector_color="white",
+        nbin=5,
+        psf_FWHM=None,
+        bmaj=None,
+        bmin=None,
+        bpa=None,
+        plot_beam=None,
+        conv_method=None,
+        mask=None,
+        cmap=None,
+        ax=None,
+        no_xlabel=False,
+        no_ylabel=False,
+        no_xticks=False,
+        no_yticks=False,
+        title=None,
+        limit=None,
+        limits=None,
+        coronagraph=None,
+        clear=False,
+        Tb=False,
+    ):
         # Todo:
         #  - plot a selected contribution
         #  - add a mask on the star ?
@@ -72,22 +108,22 @@ class Image:
             ax = plt.gca()
             ax.cla()
 
-        pola_needed = type in ['Q','U','Qphi','Uphi','P','PI','PA'] or pola_vector
-        contrib_needed = type in ['star','scatt','em_th','scatt_em_th']
+        pola_needed = type in ['Q', 'U', 'Qphi', 'Uphi', 'P', 'PI', 'PA'] or pola_vector
+        contrib_needed = type in ['star', 'scatt', 'em_th', 'scatt_em_th']
 
         if pola_needed and contrib_needed:
             raise ValueError('Cannot separate both polarisation and contributions')
 
-        #--- We first check if the requested image is present in the mcfost fits file
+        # --- We first check if the requested image is present in the mcfost fits file
         ntype_flux = self.image.shape[0]
-        if ntype_flux not in (4,8): # there is no pola
+        if ntype_flux not in (4, 8):  # there is no pola
             if pola_needed:
                 raise ValueError('The model does not have polarisation data')
-        elif ntype_flux not in (5,8): # there is no contribution
+        elif ntype_flux not in (5, 8):  # there is no contribution
             if contrib_needed:
                 raise ValueError('The model does not have contribution data')
 
-        #--- Compute pixel scale and extent of image
+        # --- Compute pixel scale and extent of image
         if axes_unit.lower() == 'arcsec':
             pix_scale = self.pixelscale
             xlabel = r'$\Delta$ Ra ["]'
@@ -101,89 +137,91 @@ class Image:
             xlabel = r'$\Delta$ x [pix]'
             ylabel = r'$\Delta$ y [pix]'
         else:
-            raise ValueError("Unknown unit for axes_units: "+axes_unit)
-        halfsize = np.asarray(self.image.shape[-2:])/2 * pix_scale
+            raise ValueError("Unknown unit for axes_units: " + axes_unit)
+        halfsize = np.asarray(self.image.shape[-2:]) / 2 * pix_scale
         extent = [-halfsize[0], halfsize[0], -halfsize[1], halfsize[1]]
 
-        #--- Beam or psf: psf_FWHM and bmaj and bmin are in arcsec, bpa in deg
+        # --- Beam or psf: psf_FWHM and bmaj and bmin are in arcsec, bpa in deg
         i_convolve = False
         beam = None
         if psf_FWHM is not None:
-            sigma = psf_FWHM / self.pixelscale * (2.*np.sqrt(2.*np.log(2))) # in pixels
+            sigma = (
+                psf_FWHM / self.pixelscale * (2.0 * np.sqrt(2.0 * np.log(2)))
+            )  # in pixels
             beam = Gaussian2DKernel(sigma)
             i_convolve = True
             bmin = psf_FWHM
             bmaj = psf_FWHM
-            bpa=0
+            bpa = 0
             if plot_beam is None:
                 plot_beam = True
 
         if bmaj is not None:
-            sigma_x = bmin / self.pixelscale * FWHM_to_sigma # in pixels
-            sigma_y = bmaj / self.pixelscale * FWHM_to_sigma # in pixels
-            beam = Gaussian2DKernel(sigma_x,sigma_y,bpa * np.pi/180)
+            sigma_x = bmin / self.pixelscale * FWHM_to_sigma  # in pixels
+            sigma_y = bmaj / self.pixelscale * FWHM_to_sigma  # in pixels
+            beam = Gaussian2DKernel(sigma_x, sigma_y, bpa * np.pi / 180)
             i_convolve = True
             if plot_beam is None:
                 plot_beam = True
 
-        #--- Selecting convolution function
+        # --- Selecting convolution function
         if conv_method is None:
             conv_method = convolve_fft
 
-        #--- Intermediate images
+        # --- Intermediate images
         if pola_needed:
-            I = self.image[0,i,iaz,:,:]
-            Q = self.image[1,i,iaz,:,:]
-            U = self.image[2,i,iaz,:,:]
+            I = self.image[0, i, iaz, :, :]
+            Q = self.image[1, i, iaz, :, :]
+            U = self.image[2, i, iaz, :, :]
         elif contrib_needed:
             if pola_needed:
-                n_pola=4
+                n_pola = 4
             else:
-                n_pola=1
+                n_pola = 1
             if type == "star":
-                I = self.image[n_pola,i,iaz,:,:]
+                I = self.image[n_pola, i, iaz, :, :]
             elif type == "scatt":
-                I = self.image[n_pola+1,i,iaz,:,:]
+                I = self.image[n_pola + 1, i, iaz, :, :]
             elif type == "em_th":
-                I = self.image[n_pola+2,i,iaz,:,:]
+                I = self.image[n_pola + 2, i, iaz, :, :]
             elif type == "scatt_em_th":
-                I = self.image[n_pola+3,i,iaz,:,:]
+                I = self.image[n_pola + 3, i, iaz, :, :]
         else:
             if self.is_casa:
-                I = self.image[i,iaz,:,:]
+                I = self.image[i, iaz, :, :]
             else:
-                I = self.image[0,i,iaz,:,:]
+                I = self.image[0, i, iaz, :, :]
 
-        #--- Convolve with beam
+        # --- Convolve with beam
         if i_convolve:
-            I = conv_method(I,beam)
+            I = conv_method(I, beam)
             if pola_needed:
-                Q = conv_method(Q,beam)
-                U = conv_method(U,beam)
+                Q = conv_method(Q, beam)
+                U = conv_method(U, beam)
 
-        #-- Conversion to brightness temperature
+        # -- Conversion to brightness temperature
         if Tb:
             if self.is_casa:
                 I = Jy_to_Tb(I, self.freq, self.pixelscale)
             else:
                 I = Wm2_to_Tb(I, self.freq, self.pixelscale)
                 I = np.nan_to_num(I)
-                print("Max Tb=",np.max(I), "K")
+                print("Max Tb=", np.max(I), "K")
 
-        #--- Coronagraph: in mas
+        # --- Coronagraph: in mas
         if coronagraph is not None:
-            halfsize = np.asarray(self.image.shape[-2:])/2
-            posx = np.linspace(-halfsize[0],halfsize[0],self.nx)
-            posy = np.linspace(-halfsize[1],halfsize[1],self.ny)
-            meshx, meshy = np.meshgrid(posx,posy)
-            radius_pixel = np.sqrt(meshx**2 + meshy**2)
+            halfsize = np.asarray(self.image.shape[-2:]) / 2
+            posx = np.linspace(-halfsize[0], halfsize[0], self.nx)
+            posy = np.linspace(-halfsize[1], halfsize[1], self.ny)
+            meshx, meshy = np.meshgrid(posx, posy)
+            radius_pixel = np.sqrt(meshx ** 2 + meshy ** 2)
             radius_mas = radius_pixel * pix_scale * 1000
-            I[radius_mas < coronagraph] = 0.
+            I[radius_mas < coronagraph] = 0.0
             if pola_needed:
-                Q[radius_mas < coronagraph] = 0.
-                U[radius_mas < coronagraph] = 0.
+                Q[radius_mas < coronagraph] = 0.0
+                U[radius_mas < coronagraph] = 0.0
 
-        #--- Selecting image to plot & convolution
+        # --- Selecting image to plot & convolution
         unit = self.unit
         flux_name = type
         if type == 'I':
@@ -197,31 +235,31 @@ class Image:
             im = U
             _scale = 'symlog'
         elif type == 'P':
-            I = I + (I == 0.)*1e-30
-            im = 100 * np.sqrt((Q/I)**2 + (U/I)**2)
+            I = I + (I == 0.0) * 1e-30
+            im = 100 * np.sqrt((Q / I) ** 2 + (U / I) ** 2)
             unit = "%"
             _scale = 'lin'
         elif type == 'PI':
-            im = np.sqrt(np.float64(Q)**2 + np.float64(U)**2)
+            im = np.sqrt(np.float64(Q) ** 2 + np.float64(U) ** 2)
             _scale = 'log'
-        elif type in ('Qphi','Uphi'):
-            X = np.arange(1,self.nx+1) - self.cx
-            Y = np.arange(1,self.ny+1) - self.cy
-            X, Y = np.meshgrid(X,Y)
-            two_phi = 2 * np.arctan2(Y,X)
+        elif type in ('Qphi', 'Uphi'):
+            X = np.arange(1, self.nx + 1) - self.cx
+            Y = np.arange(1, self.ny + 1) - self.cy
+            X, Y = np.meshgrid(X, Y)
+            two_phi = 2 * np.arctan2(Y, X)
             if type == 'Qphi':
-                im =  Q * np.cos(two_phi) + U * np.sin(two_phi)
-            else: # Uphi
+                im = Q * np.cos(two_phi) + U * np.sin(two_phi)
+            else:  # Uphi
                 im = -Q * np.sin(two_phi) + U * np.cos(two_phi)
             _scale = 'symlog'
 
-        #--- Plot range and color scale
+        # --- Plot range and color scale
         if vmax is None:
             vmax = im.max()
         if fpeak is not None:
             vmax = im.max() * fpeak
         if vmin is None:
-            if (type in ["Q","U"]):
+            if type in ["Q", "U"]:
                 vmin = -vmax
             else:
                 vmin = im.min()
@@ -229,24 +267,24 @@ class Image:
         if scale is None:
             scale = _scale
         if scale == 'symlog':
-            norm = colors.SymLogNorm(1e-6*vmax,vmin=vmin, vmax=vmax, clip=True)
+            norm = colors.SymLogNorm(1e-6 * vmax, vmin=vmin, vmax=vmax, clip=True)
         elif scale == 'log':
-            if (vmin <= 0.0):
+            if vmin <= 0.0:
                 vmin = 1e-6 * vmax
             print(vmin)
             norm = colors.LogNorm(vmin=vmin, vmax=vmax, clip=True)
         elif scale == 'lin':
             norm = colors.Normalize(vmin=vmin, vmax=vmax, clip=True)
         else:
-            raise ValueError("Unknown color scale: "+scale)
+            raise ValueError("Unknown color scale: " + scale)
 
-        #--- Set color map
+        # --- Set color map
         if cmap is None:
             cmap = default_cmap
         try:
             cmap = copy.copy(cm.get_cmap(cmap))
         except:
-            raise ValueError("Unknown colormap: "+cmap)
+            raise ValueError("Unknown colormap: " + cmap)
         try:
             cmap.set_bad(cmap.colors[0])
         except:
@@ -255,15 +293,15 @@ class Image:
             except:
                 raise Warning("Can't set bad values from given colormap")
 
-        #--- Making the actual plot
-        img = ax.imshow(im, norm=norm, extent=extent, origin='lower',cmap=cmap)
+        # --- Making the actual plot
+        img = ax.imshow(im, norm=norm, extent=extent, origin='lower', cmap=cmap)
 
         if limit is not None:
-            limits = [-limit,limit,-limit,limit]
+            limits = [-limit, limit, -limit, limit]
 
         if limits is not None:
-            ax.set_xlim(limits[0],limits[1])
-            ax.set_ylim(limits[2],limits[3])
+            ax.set_xlim(limits[0], limits[1])
+            ax.set_ylim(limits[2], limits[3])
 
         if not no_xlabel:
             ax.set_xlabel(xlabel)
@@ -278,56 +316,85 @@ class Image:
         if title is not None:
             ax.set_title(title)
 
-        #--- Colorbar
+        # --- Colorbar
         if colorbar:
             divider = make_axes_locatable(ax)
             cax = divider.append_axes("right", size="5%", pad=0.05)
-            cb = plt.colorbar(img,cax=cax)
-            formatted_unit = unit.replace("-1","$^{-1}$").replace("-2","$^{-2}$")
-            cb.set_label(flux_name+" ["+formatted_unit+"]")
+            cb = plt.colorbar(img, cax=cax)
+            formatted_unit = unit.replace("-1", "$^{-1}$").replace("-2", "$^{-2}$")
+            cb.set_label(flux_name + " [" + formatted_unit + "]")
 
-        #--- Overplotting polarisation vectors
+        # --- Overplotting polarisation vectors
         if pola_vector:
-            X = (np.arange(1,self.nx+1) - self.cx) * pix_scale
-            Y = (np.arange(1,self.ny+1) - self.cy) * pix_scale
-            X, Y = np.meshgrid(X,Y)
+            X = (np.arange(1, self.nx + 1) - self.cx) * pix_scale
+            Y = (np.arange(1, self.ny + 1) - self.cy) * pix_scale
+            X, Y = np.meshgrid(X, Y)
 
-            Xb = bin_image(X,nbin,func=np.mean)
-            Yb = bin_image(Y,nbin,func=np.mean)
-            Ib = bin_image(I,nbin)
-            Qb = bin_image(Q,nbin)
-            Ub = bin_image(U,nbin)
+            Xb = bin_image(X, nbin, func=np.mean)
+            Yb = bin_image(Y, nbin, func=np.mean)
+            Ib = bin_image(I, nbin)
+            Qb = bin_image(Q, nbin)
+            Ub = bin_image(U, nbin)
 
-            pola = 100 * np.sqrt((Qb/Ib)**2 + (Ub/Ib)**2)
-            theta = 0.5 * np.arctan2(Ub,Qb)
-            pola_x = -pola * np.sin(theta) # Ref is N (vertical axis) --> sin, and Est is toward left --> -
-            pola_y =  pola * np.cos(theta)
+            pola = 100 * np.sqrt((Qb / Ib) ** 2 + (Ub / Ib) ** 2)
+            theta = 0.5 * np.arctan2(Ub, Qb)
+            pola_x = -pola * np.sin(
+                theta
+            )  # Ref is N (vertical axis) --> sin, and Est is toward left --> -
+            pola_y = pola * np.cos(theta)
 
-            plt.quiver(Xb, Yb, pola_x, pola_y, headwidth=0, headlength=0,
-                       headaxislength=0.0, pivot='middle', color=vector_color)
+            plt.quiver(
+                Xb,
+                Yb,
+                pola_x,
+                pola_y,
+                headwidth=0,
+                headlength=0,
+                headaxislength=0.0,
+                pivot='middle',
+                color=vector_color,
+            )
 
-        #--- Adding beam
+        # --- Adding beam
         if plot_beam:
             dx = 0.125
             dy = 0.125
-            beam = Ellipse(ax.transLimits.inverted().transform((dx, dy)),
-                           width=bmin, height=bmaj, angle=bpa,
-                           fill=True, color="grey")
+            beam = Ellipse(
+                ax.transLimits.inverted().transform((dx, dy)),
+                width=bmin,
+                height=bmaj,
+                angle=bpa,
+                fill=True,
+                color="grey",
+            )
             ax.add_patch(beam)
 
-        #--- Adding mask
+        # --- Adding mask
         if mask is not None:
             dx = 0.5
             dy = 0.5
-            mask = Ellipse(ax.transLimits.inverted().transform((dx, dy)),
-                           width=2*mask, height=2*mask,
-                           fill=True, color='grey')
+            mask = Ellipse(
+                ax.transLimits.inverted().transform((dx, dy)),
+                width=2 * mask,
+                height=2 * mask,
+                fill=True,
+                color='grey',
+            )
             ax.add_patch(mask)
 
-        #--- Return
+        # --- Return
         return img
 
-    def calc_vis(self, i=0, iaz=0, hor=True, Jy=False, klambda=False, Mlambda=False, color='black'):
+    def calc_vis(
+        self,
+        i=0,
+        iaz=0,
+        hor=True,
+        Jy=False,
+        klambda=False,
+        Mlambda=False,
+        color='black',
+    ):
 
         # smoothing, christophe suggest I may need this later
         #   ou = 1;
@@ -354,17 +421,20 @@ class Image:
 
         # error message if klambda and Mlambda sccales are selected
         if klambda and Mlambda:
-            raise Exception("Cannot plot visabilities on two different scales (k and M), set one to False")
+            raise Exception(
+                "Cannot plot visabilities on two different scales (k and M), set one to False"
+            )
 
         # Selecting image
-        im=self.image[0,i,iaz,:,:]
+        im = self.image[0, i, iaz, :, :]
 
         # padding the image for a smoother curve
         def pad_with(vector, pad_width, iaxis, kwargs):
             pad_value = kwargs.get('padder', 0)
-            vector[:pad_width[0]] = pad_value
-            vector[-pad_width[1]:] = pad_value
+            vector[: pad_width[0]] = pad_value
+            vector[-pad_width[1] :] = pad_value
             return vector
+
         im = np.pad(im, 1000, pad_with)
 
         # fft
@@ -372,31 +442,31 @@ class Image:
 
         # Baselines
         size = len(fim)
-        center = size/2
+        center = size / 2
 
         # converting from arcsecond to radian
-        pix_size = self.pixelscale/3600. * np.pi/180.
+        pix_size = self.pixelscale / 3600.0 * np.pi / 180.0
 
         # pixel size in the uv plane
-        pix_fft = 1.0/pix_size
+        pix_fft = 1.0 / pix_size
 
         # pixel in wavelength (normalising in wavelength)
-        pix=self.wl*1e-6*pix_fft
+        pix = self.wl * 1e-6 * pix_fft
 
-        baselines=np.linspace(0,int(pix/2),int(size/2))
+        baselines = np.linspace(0, int(pix / 2), int(size / 2))
 
         # visabilities
         if hor:
-            vis = fim[0,0:int(size/2)]
+            vis = fim[0, 0 : int(size / 2)]
         else:
-            vis = fim[0:int(size/2),0]
+            vis = fim[0 : int(size / 2), 0]
 
         # convert to Jy
         if Jy:
-            Wm2_to_Jy(vis,sc.c/self.wl)
-            ylabel="Correlated flux [Jy]"
+            Wm2_to_Jy(vis, sc.c / self.wl)
+            ylabel = "Correlated flux [Jy]"
         else:
-            ylabel="Correlated flux [W.m$^{-2}$.Hz$^{-1}$]"
+            ylabel = "Correlated flux [W.m$^{-2}$.Hz$^{-1}$]"
 
         if klambda:
             baselines = baselines / (self.wl * 1e-3)

--- a/pymcfost/line.py
+++ b/pymcfost/line.py
@@ -7,6 +7,7 @@ from matplotlib.patches import Ellipse
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import numpy as np
+
 try:
     import progressbar
 except ImportError:
@@ -39,16 +40,16 @@ class Line:
     def _read(self):
         # Read ray-traced image
         try:
-            hdu = fits.open(self.dir+"/"+self._line_file)
+            hdu = fits.open(self.dir + "/" + self._line_file)
             self.lines = hdu[0].data
             # Read a few keywords in header
-            self.pixelscale =  hdu[0].header['CDELT2'] * 3600. # arcsec
-            self.unit     =  hdu[0].header['BUNIT']
-            self.cx       =  hdu[0].header['CRPIX1']
-            self.cy       =  hdu[0].header['CRPIX2']
-            self.nx       =  hdu[0].header['NAXIS1']
-            self.ny       =  hdu[0].header['NAXIS2']
-            self.nv       =  hdu[0].header['NAXIS3']
+            self.pixelscale = hdu[0].header['CDELT2'] * 3600.0  # arcsec
+            self.unit = hdu[0].header['BUNIT']
+            self.cx = hdu[0].header['CRPIX1']
+            self.cy = hdu[0].header['CRPIX2']
+            self.nx = hdu[0].header['NAXIS1']
+            self.ny = hdu[0].header['NAXIS2']
+            self.nv = hdu[0].header['NAXIS3']
 
             if self.unit == "JY/PIXEL":
                 self.is_casa = True
@@ -59,8 +60,9 @@ class Line:
                     self.CRPIX3 = hdu[0].header['CRPIX3']
                     self.CRVAL3 = hdu[0].header['CRVAL3']
                     self.CDELT3 = hdu[0].header['CDELT3']
-                    self.velocity = self.CRVAL3 + self.CDELT3 * \
-                            (np.arange(1,self.nv+1) - self.CRPIX3) # km/s
+                    self.velocity = self.CRVAL3 + self.CDELT3 * (
+                        np.arange(1, self.nv + 1) - self.CRPIX3
+                    )  # km/s
 
                 else:
                     raise ValueError("Velocity type is not recognised")
@@ -69,19 +71,50 @@ class Line:
                 self.cont = hdu[1].data
 
                 self.ifreq = hdu[2].data
-                self.freq = hdu[3].data # frequencies of the transition
-                self.velocity = hdu[4].data / 1000 #km/s
+                self.freq = hdu[3].data  # frequencies of the transition
+                self.velocity = hdu[4].data / 1000  # km/s
 
-            self.dv = self.velocity[1]-self.velocity[0]
+            self.dv = self.velocity[1] - self.velocity[0]
 
             hdu.close()
         except OSError:
             print('cannot open', self._line_file)
 
-    def plot_map(self,i=0,iaz=0,iTrans=0,v=None,iv=None,insert=False,substract_cont=False,moment=None,
-                 psf_FWHM=None,bmaj=None,bmin=None,bpa=None,plot_beam=None,axes_unit="arcsec",conv_method=None,
-                 fmax=None,fmin=None,fpeak=None,dynamic_range=1e3,color_scale=None,colorbar=True,cmap=None,
-                 ax=None,no_xlabel=False,no_ylabel=False,no_xticks=False,no_yticks=False,title=None,limit=None,limits=None,Tb=False,Delta_v = None):
+    def plot_map(
+        self,
+        i=0,
+        iaz=0,
+        iTrans=0,
+        v=None,
+        iv=None,
+        insert=False,
+        substract_cont=False,
+        moment=None,
+        psf_FWHM=None,
+        bmaj=None,
+        bmin=None,
+        bpa=None,
+        plot_beam=None,
+        axes_unit="arcsec",
+        conv_method=None,
+        fmax=None,
+        fmin=None,
+        fpeak=None,
+        dynamic_range=1e3,
+        color_scale=None,
+        colorbar=True,
+        cmap=None,
+        ax=None,
+        no_xlabel=False,
+        no_ylabel=False,
+        no_xticks=False,
+        no_yticks=False,
+        title=None,
+        limit=None,
+        limits=None,
+        Tb=False,
+        Delta_v=None,
+    ):
         # Todo:
         # - allow user to change brightness unit : W.m-1, Jy, Tb
         # - print molecular info (eg CO J=3-2)
@@ -91,12 +124,12 @@ class Line:
         if ax is None:
             ax = plt.gca()
 
-        #-- Selecting channel corresponding to a given velocity
+        # -- Selecting channel corresponding to a given velocity
         if v is not None:
             iv = np.abs(self.velocity - v).argmin()
             print("Selecting channel #", iv)
 
-        #--- Compute pixel scale and extent of image
+        # --- Compute pixel scale and extent of image
         if axes_unit.lower() == 'arcsec':
             pix_scale = self.pixelscale
             xlabel = r'$\Delta$ Ra ["]'
@@ -110,71 +143,82 @@ class Line:
             xlabel = r'$\Delta$ x [pix]'
             ylabel = r'$\Delta$ y [pix]'
         else:
-            raise ValueError("Unknown unit for axes_units: "+axes_unit)
-        halfsize = np.asarray(self.lines.shape[-2:])/2 * pix_scale
+            raise ValueError("Unknown unit for axes_units: " + axes_unit)
+        halfsize = np.asarray(self.lines.shape[-2:]) / 2 * pix_scale
         extent = [-halfsize[0], halfsize[0], -halfsize[1], halfsize[1]]
 
-        #-- set color map
+        # -- set color map
         if cmap is None:
-            if moment==1:
+            if moment == 1:
                 cmap = "RdBu"
             else:
                 cmap = default_cmap
 
-        #-- beam or psf : psf_FWHM and bmaj and bmin are in arcsec, bpa in deg
+        # -- beam or psf : psf_FWHM and bmaj and bmin are in arcsec, bpa in deg
         i_convolve = False
         beam = None
         if psf_FWHM is not None:
-            sigma = psf_FWHM / self.pixelscale * (2.*np.sqrt(2.*np.log(2))) # in pixels
+            sigma = (
+                psf_FWHM / self.pixelscale * (2.0 * np.sqrt(2.0 * np.log(2)))
+            )  # in pixels
             beam = Gaussian2DKernel(sigma)
             i_convolve = True
             bmin = psf_FWHM
             bmaj = psf_FWHM
-            bpa=0
+            bpa = 0
             if plot_beam is None:
                 plot_beam = True
 
         if bmaj is not None:
-            sigma_x = bmin / self.pixelscale * FWHM_to_sigma # in pixels
-            sigma_y = bmaj / self.pixelscale * FWHM_to_sigma # in pixels
-            beam = Gaussian2DKernel(sigma_x,sigma_y, bpa * np.pi/180)
+            sigma_x = bmin / self.pixelscale * FWHM_to_sigma  # in pixels
+            sigma_y = bmaj / self.pixelscale * FWHM_to_sigma  # in pixels
+            beam = Gaussian2DKernel(sigma_x, sigma_y, bpa * np.pi / 180)
             i_convolve = True
             if plot_beam is None:
                 plot_beam = True
 
-        #-- Selecting convolution function
+        # -- Selecting convolution function
         if conv_method is None:
             conv_method = convolve_fft
 
-        #-- Selection of image to plot
+        # -- Selection of image to plot
         if moment is not None:
-            im = self.get_moment_map(i=i, iaz=iaz, iTrans=iTrans, moment=moment, beam=beam, conv_method=conv_method)
+            im = self.get_moment_map(
+                i=i,
+                iaz=iaz,
+                iTrans=iTrans,
+                moment=moment,
+                beam=beam,
+                conv_method=conv_method,
+            )
         else:
             # individual channel
             if self.is_casa:
-                cube = self.lines[:,:,:]
-                #im = self.lines[iv+1,:,:])
+                cube = self.lines[:, :, :]
+                # im = self.lines[iv+1,:,:])
             else:
-                cube = self.lines[i,iaz,iTrans,:,:,:]
-                #im = self.lines[i,iaz,iTrans,iv,:,:]
+                cube = self.lines[i, iaz, iTrans, :, :, :]
+                # im = self.lines[i,iaz,iTrans,iv,:,:]
 
-                #-- continuum substraction
+                # -- continuum substraction
                 if substract_cont:
-                    cube = np.maximum(cube - self.cont[i,iaz,iTrans,np.newaxis,:,:], 0.)
+                    cube = np.maximum(
+                        cube - self.cont[i, iaz, iTrans, np.newaxis, :, :], 0.0
+                    )
 
             # Convolve spectrally
             if Delta_v is not None:
-                print("Spectral convolution at ",Delta_v, "km/s")
+                print("Spectral convolution at ", Delta_v, "km/s")
                 # Creating a Hanning function with 101 points
                 n_window = 101
                 w = np.hanning(n_window)
 
                 # For each pixel, resampling the spectrum between -FWHM to FWHM
                 # then integrating over convolution window
-                v_new = self.velocity[iv] + np.linspace(-1,1,n_window) * Delta_v
+                v_new = self.velocity[iv] + np.linspace(-1, 1, n_window) * Delta_v
 
-                iv_min = int(iv - Delta_v/self.dv - 1)
-                iv_max = int(iv + Delta_v/self.dv + 2)
+                iv_min = int(iv - Delta_v / self.dv - 1)
+                iv_max = int(iv + Delta_v / self.dv + 2)
 
                 print(iv_min, iv_max, iv_max - iv_min)
 
@@ -182,59 +226,61 @@ class Line:
 
                 print(v_new)
 
-                im = np.zeros([self.nx,self.ny])
+                im = np.zeros([self.nx, self.ny])
                 for j in range(self.ny):
                     for i in range(self.nx):
-                        f = interpolate.interp1d(self.velocity[iv_min:iv_max], cube[iv_min:iv_max,i,j])
-                        im[i,j] = np.average(f(v_new))
+                        f = interpolate.interp1d(
+                            self.velocity[iv_min:iv_max], cube[iv_min:iv_max, i, j]
+                        )
+                        im[i, j] = np.average(f(v_new))
             else:
-                im = cube[iv,:,:]
+                im = cube[iv, :, :]
 
-            #-- Convolve image
+            # -- Convolve image
             if i_convolve:
-                im = conv_method(im,beam)
+                im = conv_method(im, beam)
                 if plot_beam is None:
                     plot_beam = True
 
-            #-- Conversion to brightness temperature
+            # -- Conversion to brightness temperature
             if Tb:
                 if self.is_casa:
                     im = Jy_to_Tb(im, self.freq[iTrans], self.pixelscale)
                 else:
                     im = Wm2_to_Tb(im, self.freq[iTrans], self.pixelscale)
                     im = np.nan_to_num(im)
-                print("Max Tb=",np.max(im), "K")
+                print("Max Tb=", np.max(im), "K")
 
-        #--- Plot range and color map`
+        # --- Plot range and color map`
         _color_scale = 'lin'
         if fmax is None:
             fmax = im.max()
         if fpeak is not None:
             fmax = im.max() * fpeak
         if fmin is None:
-            fmin= im.min()
+            fmin = im.min()
 
-        if color_scale is None :
+        if color_scale is None:
             color_scale = _color_scale
         if color_scale == 'log':
-            if fmin <= 0.:
-                fmin = fmax/dynamic_range
+            if fmin <= 0.0:
+                fmin = fmax / dynamic_range
             norm = colors.LogNorm(vmin=fmin, vmax=fmax, clip=True)
         elif color_scale == 'lin':
             norm = colors.Normalize(vmin=fmin, vmax=fmax, clip=True)
         else:
-            raise ValueError("Unknown color scale: "+color_scale)
+            raise ValueError("Unknown color scale: " + color_scale)
 
-        #-- Make the plot
+        # -- Make the plot
         ax.cla()
-        image = ax.imshow(im, norm = norm, extent=extent, origin='lower',cmap=cmap)
+        image = ax.imshow(im, norm=norm, extent=extent, origin='lower', cmap=cmap)
 
         if limit is not None:
-            limits = [-limit,limit,-limit,limit]
+            limits = [-limit, limit, -limit, limit]
 
         if limits is not None:
-            ax.set_xlim(limits[0],limits[1])
-            ax.set_ylim(limits[2],limits[3])
+            ax.set_xlim(limits[0], limits[1])
+            ax.set_ylim(limits[2], limits[3])
 
         if not no_xlabel:
             ax.set_xlabel(xlabel)
@@ -249,113 +295,159 @@ class Line:
         if title is not None:
             ax.set_title(title)
 
-        #-- Color bar
+        # -- Color bar
         unit = self.unit
         if colorbar:
             divider = make_axes_locatable(ax)
             cax = divider.append_axes("right", size="5%", pad=0.05)
-            cb = plt.colorbar(image,cax=cax)
-            formatted_unit = unit.replace("-1","$^{-1}$").replace("-2","$^{-2}$")
+            cb = plt.colorbar(image, cax=cax)
+            formatted_unit = unit.replace("-1", "$^{-1}$").replace("-2", "$^{-2}$")
 
-            if moment==0:
-                cb.set_label("Flux ["+formatted_unit+"km.s$^{-1}$]")
-            elif moment==1:
+            if moment == 0:
+                cb.set_label("Flux [" + formatted_unit + "km.s$^{-1}$]")
+            elif moment == 1:
                 cb.set_label("Velocity [km.s$^{-1}]$")
-            elif moment==2:
+            elif moment == 2:
                 cb.set_label("Velocity dispersion [km.s$^{-1}$]")
             else:
                 if Tb:
                     cb.set_label("T$_\mathrm{b}$ [K]")
                 else:
-                    cb.set_label("Flux ["+formatted_unit+"]")
+                    cb.set_label("Flux [" + formatted_unit + "]")
 
-        #-- Adding velocity
+        # -- Adding velocity
         if moment is None:
-            ax.text(0.5,0.1,f"$\Delta$v={self.velocity[iv]:<4.2f}$\,$km/s",horizontalalignment='center',color="white",transform=ax.transAxes)
+            ax.text(
+                0.5,
+                0.1,
+                f"$\Delta$v={self.velocity[iv]:<4.2f}$\,$km/s",
+                horizontalalignment='center',
+                color="white",
+                transform=ax.transAxes,
+            )
 
-        #--- Adding beam
+        # --- Adding beam
         if plot_beam:
             dx = 0.125
             dy = 0.125
-            beam = Ellipse(ax.transLimits.inverted().transform((dx, dy)),
-                           width=bmin, height=bmaj, angle=bpa,
-                           fill=True,  color="grey")
+            beam = Ellipse(
+                ax.transLimits.inverted().transform((dx, dy)),
+                width=bmin,
+                height=bmaj,
+                angle=bpa,
+                fill=True,
+                color="grey",
+            )
             ax.add_patch(beam)
 
         return image
 
-    def plot_line(self, i=0, iaz=0, iTrans=0, psf_FWHM=None,bmaj=None,bmin=None,bpa=None,plot_beam=False,plot_cont=True):
+    def plot_line(
+        self,
+        i=0,
+        iaz=0,
+        iTrans=0,
+        psf_FWHM=None,
+        bmaj=None,
+        bmin=None,
+        bpa=None,
+        plot_beam=False,
+        plot_cont=True,
+    ):
 
         if self.is_casa:
-            line = np.sum(self.lines[:,:,:], axis=(1,2))
+            line = np.sum(self.lines[:, :, :], axis=(1, 2))
             ylabel = "Flux [Jy]"
         else:
-            line = np.sum(self.lines[i,iaz,iTrans,:,:,:], axis=(1,2))
+            line = np.sum(self.lines[i, iaz, iTrans, :, :, :], axis=(1, 2))
             ylabel = "Flux [W.m$^{-2}$]"
 
         plt.plot(self.velocity, line)
 
         if plot_cont:
             if self.is_casa:
-                Fcont = 0.5 * (line[0]+line[-1]) # approx the continuum
+                Fcont = 0.5 * (line[0] + line[-1])  # approx the continuum
             else:
-                Fcont = np.sum(self.cont[i,iaz,iTrans,:,:])
-            plt.plot([self.velocity[0],self.velocity[-1]],[Fcont,Fcont])
+                Fcont = np.sum(self.cont[i, iaz, iTrans, :, :])
+            plt.plot([self.velocity[0], self.velocity[-1]], [Fcont, Fcont])
 
         xlabel = "v [m.s$^{-1}$]"
 
         plt.xlabel(xlabel)
         plt.ylabel(ylabel)
 
-
-    def get_moment_map(self, i=0, iaz=0, iTrans=0, moment=0, beam=None, conv_method=None):
+    def get_moment_map(
+        self, i=0, iaz=0, iTrans=0, moment=0, beam=None, conv_method=None
+    ):
         """
         This returns the moment maps in physical units, ie:
          - M1 is the average velocity [km/s]
          - M2 is the velocity dispersion [km/s]
         """
         if self.is_casa:
-            cube = np.copy(self.lines[:,:,:])
+            cube = np.copy(self.lines[:, :, :])
         else:
-            cube = np.copy(self.lines[i,iaz,iTrans,:,:,:])
+            cube = np.copy(self.lines[i, iaz, iTrans, :, :, :])
 
         dv = self.velocity[1] - self.velocity[0]
 
         if beam is None:
-            M0 = np.sum(cube,axis=0) * dv
+            M0 = np.sum(cube, axis=0) * dv
         else:
-            if moment==0:
-                M0 = np.sum(cube,axis=0) * dv
-                M0 = conv_method(M0,beam)
-            else: # We need to convolve each channel indidually
-                print("Convolving individual channel maps, this may take a bit of time ....")
+            if moment == 0:
+                M0 = np.sum(cube, axis=0) * dv
+                M0 = conv_method(M0, beam)
+            else:  # We need to convolve each channel indidually
+                print(
+                    "Convolving individual channel maps, this may take a bit of time ...."
+                )
                 try:
-                    bar = progressbar.ProgressBar(maxval=self.nv, widgets=[progressbar.Bar('=', '[', ']'), ' ', progressbar.Percentage()])
+                    bar = progressbar.ProgressBar(
+                        maxval=self.nv,
+                        widgets=[
+                            progressbar.Bar('=', '[', ']'),
+                            ' ',
+                            progressbar.Percentage(),
+                        ],
+                    )
                     bar.start()
                 except:
                     pass
                 for iv in range(self.nv):
                     try:
-                        bar.update(iv+1)
+                        bar.update(iv + 1)
                     except:
                         pass
-                    channel = np.copy(cube[iv,:,:])
-                    cube[iv,:,:] = conv_method(channel,beam)
-                    M0 = np.sum(cube,axis=0) * dv
+                    channel = np.copy(cube[iv, :, :])
+                    cube[iv, :, :] = conv_method(channel, beam)
+                    M0 = np.sum(cube, axis=0) * dv
                 try:
                     bar.finish()
                 except:
                     pass
 
-        if moment >=1:
-            M1 = np.sum(cube[:,:,:] * self.velocity[:,np.newaxis,np.newaxis], axis=0) * dv / M0
+        if moment >= 1:
+            M1 = (
+                np.sum(cube[:, :, :] * self.velocity[:, np.newaxis, np.newaxis], axis=0)
+                * dv
+                / M0
+            )
 
         if moment == 2:
-            M2 = np.sqrt( np.sum(cube[:,:,:] * (self.velocity[:,np.newaxis,np.newaxis] - M1[np.newaxis,:,:])**2, axis=0) * dv / M0)
+            M2 = np.sqrt(
+                np.sum(
+                    cube[:, :, :]
+                    * (self.velocity[:, np.newaxis, np.newaxis] - M1[np.newaxis, :, :])
+                    ** 2,
+                    axis=0,
+                )
+                * dv
+                / M0
+            )
 
-        if moment==0:
+        if moment == 0:
             return M0
-        elif moment==1:
+        elif moment == 1:
             return M1
-        elif moment==2:
+        elif moment == 2:
             return M2

--- a/pymcfost/parameters.py
+++ b/pymcfost/parameters.py
@@ -1,45 +1,58 @@
 import glob
 import numpy as np
 
+
 class Photons:
     pass
+
 
 class Wavelengths:
     pass
 
+
 class Physics:
     pass
+
 
 class Dust:
     component = []
     pass
 
+
 class DustComponent:
     pass
+
 
 class Grid:
     pass
 
+
 class Map:
     pass
+
 
 class Zone:
     dust = []
     pass
 
+
 class Mol:
     molecule = []
     pass
 
+
 class Molecule:
     pass
+
 
 class Star:
     pass
 
+
 class Simu:
     version = float()
     pass
+
 
 class Params:
 
@@ -64,19 +77,24 @@ class Params:
             f = []
             # Reading file and removing comments
             for line in file:
-                if ((not line.startswith("#")) and (len(line)>1)): # Skipping comments and empty lines
-                   f += [line]
+                if (not line.startswith("#")) and (
+                    len(line) > 1
+                ):  # Skipping comments and empty lines
+                    f += [line]
             f = iter(f)
 
-        #-- Version of the parameter file --
+        # -- Version of the parameter file --
         line = next(f).split()
         self.simu.version = float(line[0])
-        if (self.simu.version < self._minimum_version-1e-3):
+        if self.simu.version < self._minimum_version - 1e-3:
             print("Parameter file version is ", self.simu.version)
-            raise Exception('Parameter file version must be at least {ver:.2f}'.format(ver=self._minimum_version))
+            raise Exception(
+                'Parameter file version must be at least {ver:.2f}'.format(
+                    ver=self._minimum_version
+                )
+            )
 
-
-        #-- Number of photon packages --
+        # -- Number of photon packages --
         line = next(f).split()
         self.phot.nphot_T = float(line[0])
         line = next(f).split()
@@ -84,7 +102,7 @@ class Params:
         line = next(f).split()
         self.phot.nphot_image = float(line[0])
 
-        #-- Wavelengths --
+        # -- Wavelengths --
         line = next(f).split()
         self.wavelengths.n_wl = int(line[0])
         self.wavelengths.wl_min = float(line[1])
@@ -102,7 +120,7 @@ class Params:
         self.simu.separate_contrib = line[0][0] == "T"
         self.simu.separate_pola = line[1][0] == "T"
 
-        #-- Grid --
+        # -- Grid --
         line = next(f).split()
         self.grid.type = int(line[0])
         line = next(f).split()
@@ -111,7 +129,7 @@ class Params:
         self.grid.n_az = int(line[2])
         self.grid.n_rad_in = int(line[3])
 
-        #-- Maps --
+        # -- Maps --
         line = next(f).split()
         self.map.nx = int(line[0])
         self.map.ny = int(line[1])
@@ -134,14 +152,14 @@ class Params:
         line = next(f).split()
         self.map.PA = float(line[0])
 
-        #-- Scattering method --
+        # -- Scattering method --
         line = next(f).split()
         self.simu.scattering_method = int(line[0])
 
         line = next(f).split()
         self.simu.phase_function_method = int(line[0])
 
-        #-- Symetries --
+        # -- Symetries --
         line = next(f).split()
         self.simu.image_symmetry = line[0][0] == "T"
         line = next(f).split()
@@ -149,7 +167,7 @@ class Params:
         line = next(f).split()
         self.simu.axial_symmetry = line[0][0] == "T"
 
-        #-- Disk physics --
+        # -- Disk physics --
         line = next(f).split()
         self.simu.dust_settling_type = int(line[0])
         self.simu.dust_settling_exp = float(line[1])
@@ -168,12 +186,12 @@ class Params:
         self.simu.viscous_heating = line[0][0] == "True"
         self.simu.viscosity = float(line[1])
 
-        #-- Number of zones --
+        # -- Number of zones --
         line = next(f).split()
         n_zones = int(line[0])
         self.simu.n_zones = n_zones
 
-        #-- Density structure --
+        # -- Density structure --
         z = Zone()
         for k in range(n_zones):
             self.zones.append(z)
@@ -203,7 +221,7 @@ class Params:
             self.zones[k].surface_density_exp = float(line[0])
             self.zones[k].m_gamma_exp = float(line[1])
 
-        #-- Grain properties --
+        # -- Grain properties --
         d = Dust
         for k in range(n_zones):
             line = next(f).split()
@@ -239,7 +257,7 @@ class Params:
                 self.zones[k].dust[j].aexp = float(line[2])
                 self.zones[k].dust[j].n_grains = int(line[3])
 
-        #-- Molecular settings --
+        # -- Molecular settings --
         line = next(f).split()
         self.mol.compute_pop = line[0][0] == "T"
         self.mol.compute_pop_accurate = line[1][0] == "T"
@@ -276,9 +294,11 @@ class Params:
             self.mol.molecule[k].n_trans = nTrans
 
             line = next(f).split()
-            self.mol.molecule[k].transitions = list(map(int, line[0:nTrans])) # convert list of str to int
+            self.mol.molecule[k].transitions = list(
+                map(int, line[0:nTrans])
+            )  # convert list of str to int
 
-        #-- Star properties --
+        # -- Star properties --
         line = next(f).split()
         n_stars = int(line[0])
         self.simu.n_stars = n_stars
@@ -302,31 +322,30 @@ class Params:
             self.stars[k].fUV = float(line[0])
             self.stars[k].slope_UV = float(line[1])
 
-
     def __str__(self):
         """ Return a formatted parameter file. Currently returns v3.0 format
         """
 
-        #-- Photon packets --
+        # -- Photon packets --
         txt = f"""3.0                       mcfost version\n
 #-- Number of photon packages --
   {self.phot.nphot_T:<10.5g}              nbr_photons_eq_th  : T computation
   {self.phot.nphot_SED:<10.5g}              nbr_photons_lambda : SED computation
   {self.phot.nphot_image:<10.5g}              nbr_photons_image : images computation\n\n"""
 
-        #-- Wavelengths --
+        # -- Wavelengths --
         txt += f"""#-- Wavelength --
   {self.wavelengths.n_wl:<4d} {self.wavelengths.wl_min:<5.1f} {self.wavelengths.wl_max:<7g}      n_lambda, lambda_min, lambda_max [microns]
   {self.simu.compute_T} {self.simu.compute_SED} {self.simu.use_default_wl}         compute temperature?, compute sed?, use default wavelength grid ?
   {self.wavelengths.file}            wavelength file (if previous parameter is F)
   {self.simu.separate_contrib} {self.simu.separate_pola}              separation of different contributions?, stokes parameters?\n\n"""
 
-        #-- Grid --
+        # -- Grid --
         txt += f"""#-- Grid geometry and size --
   {self.grid.type:>1d}                       1 = cylindrical, 2 = spherical
   {self.grid.n_rad} {self.grid.nz} {self.grid.n_az} {self.grid.n_rad_in}             n_rad (log distribution), nz (or n_theta), n_az, n_rad_in\n\n"""
 
-        #-- Maps --
+        # -- Maps --
         txt += f"""#-- Maps --
   {self.map.nx} {self.map.ny} {self.map.size:5.1f}           grid (nx,ny), size [au]
   {self.map.RT_imin:<4.1f}  {self.map.RT_imax:<4.1f}  {self.map.RT_ntheta:>2d} {self.map.lRT_centered}    RT: imin, imax, n_incl, centered ?
@@ -334,18 +353,18 @@ class Params:
   {self.map.distance:<6.2f}                  distance (pc)
   {self.map.PA:<6.2f}                  disk PA\n\n"""
 
-        #-- Scattering method --
+        # -- Scattering method --
         txt += f"""#-- Scattering method --
   {self.simu.scattering_method}                       0=auto, 1=grain prop, 2=cell prop
   {self.simu.phase_function_method}                       1=Mie, 2=hg (2 implies the loss of polarizarion)\n\n"""
 
-        #-- Symetries --
+        # -- Symetries --
         txt += f"""#-- Symmetries --
   {self.simu.image_symmetry}                    image symmetry
   {self.simu.central_symmetry}                    central symmetry
   {self.simu.axial_symmetry}                    axial symmetry (important only if N_phi > 1)\n\n"""
 
-        #-- Disk physics --
+        # -- Disk physics --
         txt += f"""#Disk physics
   {self.simu.dust_settling_type}  {self.simu.dust_settling_exp:<6.2f}  {self.simu.a_settling:<6.2f}       dust_settling (0=no settling, 1=parametric, 2=Dubrulle, 3=Fromang), exp_strat, a_strat (for parametric settling)
   {self.simu.radial_migration}                   dust radial migration
@@ -353,11 +372,11 @@ class Params:
   {self.simu.hydrostatic_eq}                   hydrostatic equilibrium
   {self.simu.viscous_heating}  {self.simu.viscosity:4.1g}            viscous heating, alpha_viscosity\n\n"""
 
-        #-- Number of zones --
+        # -- Number of zones --
         txt += f"""#-- Number of zones --   1 zone = 1 density structure + corresponding grain properties
   {self.simu.n_zones}\n\n"""
 
-        #-- Density structure --
+        # -- Density structure --
         txt += f"#-- Density structure --\n"
         for k in range(self.simu.n_zones):
             txt += f"""  {self.zones[k].geometry}                        zone type : 1 = disk, 2 = tapered-edge disk, 3 = envelope, 4 = debris disk, 5 = wall
@@ -368,10 +387,12 @@ class Params:
   {self.zones[k].surface_density_exp} {self.zones[k].m_gamma_exp}                 surface density exponent (or -gamma for tappered-edge disk or volume density for envelope), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)\n\n"""
         txt += f"\n"
 
-        #-- Grain properties --
+        # -- Grain properties --
         txt += f"#-- Grain properties --\n"
         for k in range(self.simu.n_zones):
-            txt += f"  {self.zones[k].n_species}                      Number of species\n"
+            txt += (
+                f"  {self.zones[k].n_species}                      Number of species\n"
+            )
             for j in range(self.zones[k].n_species):
                 txt += f"  Mie {self.zones[k].dust[j].n_components} {self.zones[k].dust[j].mixing_rule} {self.zones[k].dust[j].porosity:<5.2f} {self.zones[k].dust[j].mass_fraction:<5.2f} {self.zones[k].dust[j].DHS_Vmax}    Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)\n"
                 for l in range(self.zones[k].dust[j].n_components):
@@ -379,7 +400,7 @@ class Params:
                 txt += f"""  {self.zones[k].dust[j].heating_method}                          Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
   {self.zones[k].dust[j].amin} {self.zones[k].dust[j].amax}  {self.zones[k].dust[j].aexp} {self.zones[k].dust[j].n_grains}       amin, amax, aexp, nbr_grains\n\n"""
 
-        #-- Molecular settings --
+        # -- Molecular settings --
         txt += f"""#-- Molecular RT settings --
   {self.mol.compute_pop}  {self.mol.compute_pop_accurate}  {self.mol.LTE} {self.mol.profile_width}      lpop, laccurate_pop, LTE, profile width
   {self.mol.v_turb}                        v_turb [km/s]
@@ -394,7 +415,7 @@ class Params:
             txt += f" transition numbers\n"
         txt += f"\n"
 
-        #-- Star properties --
+        # -- Star properties --
         txt += f"""#-- Star properties --
   {self.simu.n_stars}  Number of stars\n"""
         for k in range(self.simu.n_stars):
@@ -407,29 +428,46 @@ class Params:
     def writeto(self, outname):
         """ Write an MCFOST parameter file to disk.  """
         outfile = open(outname, 'w')
-        outfile.write( str(self))
+        outfile.write(str(self))
         outfile.close()
-
 
     def calc_inclinations(self):
         # Calculate the inclinations for the ray-traced SEDs and images
-        if (self.map.RT_ntheta == 1):
+        if self.map.RT_ntheta == 1:
             return self.map.RT_imin
         else:
-            cos_min = np.cos(self.map.RT_imin / 180. * np.pi) ;
-            cos_max = np.cos(self.map.RT_imax / 180. * np.pi) ;
-            if (self.map.lRT_centered):
-                return np.arccos( cos_min + (np.arange(self.map.RT_ntheta) + 0.5)/self.map.RT_ntheta * (cos_max - cos_min) ) /np.pi * 180.
+            cos_min = np.cos(self.map.RT_imin / 180.0 * np.pi)
+            cos_max = np.cos(self.map.RT_imax / 180.0 * np.pi)
+            if self.map.lRT_centered:
+                return (
+                    np.arccos(
+                        cos_min
+                        + (np.arange(self.map.RT_ntheta) + 0.5)
+                        / self.map.RT_ntheta
+                        * (cos_max - cos_min)
+                    )
+                    / np.pi
+                    * 180.0
+                )
             else:
-                return np.arccos( cos_min + (np.arange(self.map.RT_ntheta))/(self.map.RT_ntheta-1) * (cos_max - cos_min) ) /np.pi * 180.
+                return (
+                    np.arccos(
+                        cos_min
+                        + (np.arange(self.map.RT_ntheta))
+                        / (self.map.RT_ntheta - 1)
+                        * (cos_max - cos_min)
+                    )
+                    / np.pi
+                    * 180.0
+                )
 
 
 def find_parameter_file(directory="./"):
 
-    list = glob.glob(directory+"/*.par*")
+    list = glob.glob(directory + "/*.par*")
     if len(list) == 1:
         return list[0]
     elif len(list) > 1:
-        raise ValueError("Multiple parameter files found in "+directory)
+        raise ValueError("Multiple parameter files found in " + directory)
     else:
-        raise ValueError("No parameter files found in "+directory)
+        raise ValueError("No parameter files found in " + directory)

--- a/pymcfost/utils.py
+++ b/pymcfost/utils.py
@@ -6,25 +6,35 @@ import astropy.units as u
 
 default_cmap = "inferno"
 
-FWHM_to_sigma = 1./(2.*np.sqrt(2.*np.log(2)))
-arcsec = np.pi/648000
+FWHM_to_sigma = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2)))
+arcsec = np.pi / 648000
+
 
 def bin_image(im, n, func=np.sum):
     # bin an image in blocks of n x n pixels
     # return a image of size im.shape/n
 
     nx = im.shape[0]
-    nx_new = nx//n
-    x0 = (nx - nx_new * n)//2
+    nx_new = nx // n
+    x0 = (nx - nx_new * n) // 2
 
     ny = im.shape[1]
-    ny_new = ny//n
-    y0 = (ny - ny_new * n)//2
+    ny_new = ny // n
+    y0 = (ny - ny_new * n) // 2
 
-    return np.reshape(np.array([func(im[x0+k1*n:(k1+1)*n,y0+k2*n:(k2+1)*n]) for k1 in range(nx_new) for k2 in range(ny_new)]),(nx_new,ny_new))
+    return np.reshape(
+        np.array(
+            [
+                func(im[x0 + k1 * n : (k1 + 1) * n, y0 + k2 * n : (k2 + 1) * n])
+                for k1 in range(nx_new)
+                for k2 in range(ny_new)
+            ]
+        ),
+        (nx_new, ny_new),
+    )
 
 
-def Wm2_to_Jy(nuFnu,nu):
+def Wm2_to_Jy(nuFnu, nu):
     '''
     Convert from W.m-2 to Jy
     nu [Hz]
@@ -32,7 +42,7 @@ def Wm2_to_Jy(nuFnu,nu):
     return 1e26 * nuFnu / nu
 
 
-def Jy_to_Wm2(Fnu,nu):
+def Jy_to_Wm2(Fnu, nu):
     '''
     Convert from Jy to W.m-2
     nu [Hz]
@@ -49,13 +59,14 @@ def Jybeam_to_Tb(Fnu, nu, bmaj, bmin):
 
      T [K]
     '''
-    beam_area = bmin * bmaj * arcsec**2 * np.pi/(4.*np.log(2.))
-    exp_m1 = 1e26 *  beam_area * 2.*sc.h/sc.c**2 * nu**3/Fnu
-    hnu_kT =  np.log1p(np.maximum(exp_m1,1e-10))
+    beam_area = bmin * bmaj * arcsec ** 2 * np.pi / (4.0 * np.log(2.0))
+    exp_m1 = 1e26 * beam_area * 2.0 * sc.h / sc.c ** 2 * nu ** 3 / Fnu
+    hnu_kT = np.log1p(np.maximum(exp_m1, 1e-10))
 
     Tb = sc.h * nu / (hnu_kT * sc.k)
 
     return Tb
+
 
 def Jy_to_Tb(Fnu, nu, pixelscale):
     '''
@@ -66,9 +77,9 @@ def Jy_to_Tb(Fnu, nu, pixelscale):
 
      T [K]
     '''
-    pixel_area = (pixelscale * arcsec)**2
-    exp_m1 = 1e16 *  pixel_area * 2.*sc.h/sc.c**2 * nu**3/Fnu
-    hnu_kT =  np.log1p(exp_m1+1e-10)
+    pixel_area = (pixelscale * arcsec) ** 2
+    exp_m1 = 1e16 * pixel_area * 2.0 * sc.h / sc.c ** 2 * nu ** 3 / Fnu
+    hnu_kT = np.log1p(exp_m1 + 1e-10)
 
     Tb = sc.h * nu / (hnu_kT * sc.k)
 
@@ -76,36 +87,43 @@ def Jy_to_Tb(Fnu, nu, pixelscale):
 
 
 def Wm2_to_Tb(nuFnu, nu, pixelscale):
-        """Convert flux converted from Wm2/pixel to K using full Planck law.
+    """Convert flux converted from Wm2/pixel to K using full Planck law.
         Convert Flux density in Jy/beam to brightness temperature [K]
         Flux [W.m-2/pixel]
         nu [Hz]
         bmaj, bmin, pixelscale in [arcsec]
         """
-        pixel_area = (pixelscale * arcsec)**2
-        exp_m1 = pixel_area * 2. * sc.h * nu**4 / (sc.c**2 * nuFnu)
-        hnu_kT = np.log1p(exp_m1+1e-10)
+    pixel_area = (pixelscale * arcsec) ** 2
+    exp_m1 = pixel_area * 2.0 * sc.h * nu ** 4 / (sc.c ** 2 * nuFnu)
+    hnu_kT = np.log1p(exp_m1 + 1e-10)
 
-        Tb = sc.h * nu / (sc.k * hnu_kT)
+    Tb = sc.h * nu / (sc.k * hnu_kT)
 
-        return Tb
+    return Tb
 
 
 class DustExtinction:
 
     import os
+
     __dirname__ = os.path.dirname(__file__)
 
     wl = []
     kext = []
 
-    _extinction_dir = __dirname__+"/extinction_laws"
+    _extinction_dir = __dirname__ + "/extinction_laws"
     _filename_start = "kext_albedo_WD_MW_"
     _filename_end = "_D03.all"
-    V = 5.47e-1 # V band wavelength in micron
+    V = 5.47e-1  # V band wavelength in micron
 
-    def __init__(self,Rv=3.1, **kwargs):
-        self.filename = self._extinction_dir+"/"+self._filename_start+str(Rv)+self._filename_end
+    def __init__(self, Rv=3.1, **kwargs):
+        self.filename = (
+            self._extinction_dir
+            + "/"
+            + self._filename_start
+            + str(Rv)
+            + self._filename_end
+        )
         self._read(**kwargs)
 
     def _read(self):
@@ -113,19 +131,21 @@ class DustExtinction:
         with open(self.filename, 'r') as file:
             f = []
             for line in file:
-                if ((not line.startswith("#")) and (len(line)>1)): # Skipping comments and empty lines
+                if (not line.startswith("#")) and (
+                    len(line) > 1
+                ):  # Skipping comments and empty lines
                     line = line.split()
                     self.wl.append(float(line[0]))
                     kpa = float(line[4])
                     albedo = float(line[1])
-                    self.kext.append(kpa/(1.-albedo))
+                    self.kext.append(kpa / (1.0 - albedo))
 
             # Normalize extinction in V band
-            kext_interp = interp1d(self.wl,self.kext)
+            kext_interp = interp1d(self.wl, self.kext)
             kextV = kext_interp(self.V)
             self.kext /= kextV
 
-    def redenning(self,wl, Av):
+    def redenning(self, wl, Av):
         """
         Computes extinction factor to apply for a given Av
         Flux_red = Flux * redenning
@@ -133,8 +153,8 @@ class DustExtinction:
         wl in micron
 
         """
-        kext_interp = interp1d(self.wl,self.kext)
+        kext_interp = interp1d(self.wl, self.kext)
         kext = kext_interp(wl)
-        tau_V = 0.4*np.log(10.)*Av
+        tau_V = 0.4 * np.log(10.0) * Av
 
         return np.exp(-tau_V * kext)


### PR DESCRIPTION
Black is a minimally configurable Python auto-formatter. It keeps the source code nicely formatted and in a standardised format. It is under the umbrella of the Python Software Foundation.

It can be installed with pip or conda.

The command used is:

black --skip-string-normalization pymcfost

The "skip-string-normalization" option keeps single quotes as single quotes, rather than converting them to double quotes (which is the Black default).

We can configure git so that it automatically runs Black on any commit.

Using Black is a personal preference that I have. I understand if you don't want to commit to this. But I think it makes a difference. Code is read more often than written. Using Black is easy, standardised, and keeps the code readable.
