### PR TITLE
CASA_simdata: fixed exportfits when config is a string

### DIFF
--- a/pymcfost/CASA_simdata.py
+++ b/pymcfost/CASA_simdata.py
@@ -85,7 +85,7 @@ def CASA_simdata(
                 resol_name = "_config=" + config
                 resol_name_script = config
             else:
-                resol_name_script = config[-1]
+                resol_name_script = config
 
     else:
         # -- Setting up for simobs_custom


### PR DESCRIPTION
The variable used to write the exportfits command used only the last character of string config.