### PR TITLE
bugfix: bool parsing (parafile)

### DIFF
--- a/pymcfost/parameters.py
+++ b/pymcfost/parameters.py
@@ -1,6 +1,10 @@
 import glob
 import numpy as np
 
+def _word_to_bool(word):
+    """convert a string to boolean according the first 2 characters."""
+    _accepted_bool_prefixes = ("T", ".T")
+    return word.upper().startswith(_accepted_bool_prefixes)
 
 class Photons:
     pass
@@ -108,16 +112,16 @@ class Params:
         self.wavelengths.wl_max = float(line[2])
 
         line = next(f).split()
-        self.simu.compute_T = line[0][0] == "T"
-        self.simu.compute_SED = line[1][0] == "T"
-        self.simu.use_default_wl = line[2][0] == "T"
+        self.simu.compute_T = _word_to_bool(line[0])
+        self.simu.compute_SED = _word_to_bool(line[1])
+        self.simu.use_default_wl = _word_to_bool(line[2])
 
         line = next(f).split()
         self.wavelengths.file = line[0]
 
         line = next(f).split()
-        self.simu.separate_contrib = line[0][0] == "T"
-        self.simu.separate_pola = line[1][0] == "T"
+        self.simu.separate_contrib = _word_to_bool(line[0])
+        self.simu.separate_pola = _word_to_bool(line[1])
 
         # -- Grid --
         line = next(f).split()
@@ -138,7 +142,7 @@ class Params:
         self.map.RT_imin = float(line[0])
         self.map.RT_imax = float(line[1])
         self.map.RT_ntheta = int(line[2])
-        self.map.lRT_centered = line[3][0] == "T"
+        self.map.lRT_centered = _word_to_bool(line[3])
 
         line = next(f).split()
         self.map.RT_az_min = float(line[0])
@@ -160,11 +164,11 @@ class Params:
 
         # -- Symetries --
         line = next(f).split()
-        self.simu.image_symmetry = line[0][0] == "T"
+        self.simu.image_symmetry = _word_to_bool(line[0])
         line = next(f).split()
-        self.simu.central_symmetry = line[0][0] == "T"
+        self.simu.central_symmetry = _word_to_bool(line[0])
         line = next(f).split()
-        self.simu.axial_symmetry = line[0][0] == "T"
+        self.simu.axial_symmetry = _word_to_bool(line[0])
 
         # -- Disk physics --
         line = next(f).split()
@@ -173,16 +177,16 @@ class Params:
         self.simu.a_settling = float(line[2])
 
         line = next(f).split()
-        self.simu.radial_migration = line[0][0] == "True"
+        self.simu.radial_migration = _word_to_bool(line[0])
 
         line = next(f).split()
-        self.simu.dust_sublimation = line[0][0] == "True"
+        self.simu.dust_sublimation = _word_to_bool(line[0])
 
         line = next(f).split()
-        self.simu.hydrostatic_eq = line[0][0] == "True"
+        self.simu.hydrostatic_eq = _word_to_bool(line[0])
 
         line = next(f).split()
-        self.simu.viscous_heating = line[0][0] == "True"
+        self.simu.viscous_heating = _word_to_bool(line[0])
         self.simu.viscosity = float(line[1])
 
         # -- Number of zones --
@@ -258,9 +262,9 @@ class Params:
 
         # -- Molecular settings --
         line = next(f).split()
-        self.mol.compute_pop = line[0][0] == "T"
-        self.mol.compute_pop_accurate = line[1][0] == "T"
-        self.mol.LTE = line[2][0] == "T"
+        self.mol.compute_pop = _word_to_bool(line[0])
+        self.mol.compute_pop_accurate = _word_to_bool(line[1])
+        self.mol.LTE = _word_to_bool(line[2])
         self.mol.profile_width = float(line[3])
 
         line = next(f).split()
@@ -283,12 +287,12 @@ class Params:
             self.mol.molecule[k].nv = int(line[1])
 
             line = next(f).split()
-            self.mol.molecule[k].cst_abundance = line[0][0] == "T"
+            self.mol.molecule[k].cst_abundance = _word_to_bool(line[0])
             self.mol.molecule[k].abundance = line[1]
             self.mol.molecule[k].abundance_file = line[2]
 
             line = next(f).split()
-            self.mol.molecule[k].ray_tracing = line[0][0] == "T"
+            self.mol.molecule[k].ray_tracing = _word_to_bool(line[0])
             nTrans = int(line[1])
             self.mol.molecule[k].n_trans = nTrans
 
@@ -312,7 +316,7 @@ class Params:
             self.stars[k].x = float(line[3])
             self.stars[k].y = float(line[4])
             self.stars[k].z = float(line[5])
-            self.stars[k].is_bb = line[6][0] == "T"
+            self.stars[k].is_bb = _word_to_bool(line[6])
 
             line = next(f).split()
             self.stars[k].file = line[0]

--- a/tests/corpus/ref3.0.para
+++ b/tests/corpus/ref3.0.para
@@ -1,0 +1,73 @@
+3.0                      mcfost version
+
+#Number of photon packages
+  1.28e5                  nbr_photons_eq_th  : T computation
+  1.28e3                  nbr_photons_lambda : SED computation
+  1.28e7                  nbr_photons_image  : images computation
+
+#Wavelength
+  50  0.1 3000.0          n_lambda, lambda_min, lambda_max [mum] Do not change this line unless you know what you are doing
+  T T T                   compute temperature?, compute sed?, use default wavelength grid for output ?
+  IMLup.lambda            wavelength file (if previous parameter is F)
+  F T                     separation of different contributions?, stokes parameters?
+
+#Grid geometry and size
+  1                       1 = cylindrical, 2 = spherical, 3 = Voronoi tesselation (this is in beta, please ask Christophe)
+  100 70 1 20             n_rad (log distribution), nz (or n_theta), n_az, n_rad_in
+
+#Maps
+  101 101 700.            grid (nx,ny), size [AU]
+  45.  45.  1  F          RT: imin, imax, n_incl, centered ?
+  0    0.   1             RT: az_min, az_max, n_az angles
+  140.0                   distance (pc)
+  0.                      disk PA
+
+#Scattering method
+  0                       0=auto, 1=grain prop, 2=cell prop
+  1                       1=Mie, 2=hg (2 implies the loss of polarizarion)
+
+#Symetries
+  T                       image symmetry
+  T                       central symmetry
+  T                       axial symmetry (important only if N_phi > 1)
+
+#Disk physics
+  0     0.50  1.0         dust_settling (0=no settling, 1=parametric, 2=Dubrulle, 3=Fromang), exp_strat, a_strat (for parametric settling)
+  F                       dust radial migration
+  F                       sublimate dust
+  F                       hydostatic equilibrium
+  F  1e-5                 viscous heating, alpha_viscosity
+
+#Number of zones : 1 zone = 1 density structure + corresponding grain properties
+  1
+
+#Density structure
+  1                       zone type : 1 = disk, 2 = tappered-edge disk, 3 = envelope, 4 = debris disk, 5 = wall
+  1.e-3    100.           dust mass,  gas-to-dust mass ratio
+  10.  100.0  2           scale height, reference radius (AU), unused for envelope, vertical profile exponent (only for debris disk)
+  1.0  0.0    300.  100.  Rin, edge, Rout, Rc (AU) Rc is only used for tappered-edge & debris disks (Rout set to 8*Rc if Rout==0)
+  1.125                   flaring exponent, unused for envelope
+  -0.5  0.0               surface density exponent (or -gamma for tappered-edge disk or volume density for envelope), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)
+
+#Grain properties
+  1  Number of species
+  Mie  1 2  0.0  1.0  0.9 Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  Draine_Si_sUV.dat  1.0  Optical indices file, volume fraction
+  1                       Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.03  1000.0 3.5 100    amin, amax [mum], aexp, n_grains (log distribution)
+
+#Molecular RT settings
+  T T T 15.               lpop, laccurate_pop, LTE, profile width (km.s^-1)
+  0.2                     v_turb (delta)
+  1                       nmol
+  co@xpol.dat 6           molecular data filename, level_max
+  1.0 20                  vmax (km.s^-1), n_speed
+  T 1.e-6 abundance.fits.gz   cst molecule abundance ?, abundance, abundance file
+  T  3                    ray tracing ?,  number of lines in ray-tracing
+  1 2 3                   transition numbers
+
+#Star properties
+  1 Number of stars
+  4000.0    2.0    1.0    0.0    0.0    0.0  T Temp, radius (solar radius),M (solar mass),x,y,z (AU), is a blackbody?
+  lte4000-3.5.NextGen.fits.gz
+  0.0    2.2  fUV, slope_fUV

--- a/tests/corpus/ref3.0_mod.para
+++ b/tests/corpus/ref3.0_mod.para
@@ -1,0 +1,85 @@
+3.0                      mcfost version
+
+#Number of photon packages
+  1.28e5                  nbr_photons_eq_th  : T computation
+  1.28e3                  nbr_photons_lambda : SED computation
+  1.28e7                  nbr_photons_image  : images computation
+
+#Wavelength
+  50  0.1 3000.0          n_lambda, lambda_min, lambda_max [mum] Do not change this line unless you know what you are doing
+  T T T                   compute temperature?, compute sed?, use default wavelength grid for output ?
+  IMLup.lambda            wavelength file (if previous parameter is F)
+  F T                     separation of different contributions?, stokes parameters?
+
+#Grid geometry and size
+  1                       1 = cylindrical, 2 = spherical, 3 = Voronoi tesselation (this is in beta, please ask Christophe)
+  100 70 1 20             n_rad (log distribution), nz (or n_theta), n_az, n_rad_in
+
+#Maps
+  101 101 700.            grid (nx,ny), size [AU]
+  45.  45.  1  F          RT: imin, imax, n_incl, centered ?
+  0    0.   1             RT: az_min, az_max, n_az angles
+  140.0                   distance (pc)
+  0.                      disk PA
+
+#Scattering method
+  0                       0=auto, 1=grain prop, 2=cell prop
+  1                       1=Mie, 2=hg (2 implies the loss of polarizarion)
+
+#Symetries
+  T                       image symmetry
+  T                       central symmetry
+  T                       axial symmetry (important only if N_phi > 1)
+
+#Disk physics
+  0     0.50  1.0         dust_settling (0=no settling, 1=parametric, 2=Dubrulle, 3=Fromang), exp_strat, a_strat (for parametric settling)
+  F                       dust radial migration
+  F                       sublimate dust
+  F                       hydostatic equilibrium
+  F  1e-5                 viscous heating, alpha_viscosity
+
+#Number of zones : 1 zone = 1 density structure + corresponding grain properties
+  1
+
+#Density structure
+  1                       zone type : 1 = disk, 2 = tappered-edge disk, 3 = envelope, 4 = debris disk, 5 = wall
+  1.e-3    100.           dust mass,  gas-to-dust mass ratio
+  10.  100.0  2           scale height, reference radius (AU), unused for envelope, vertical profile exponent (only for debris disk)
+  1.0  0.0    300.  100.  Rin, edge, Rout, Rc (AU) Rc is only used for tappered-edge & debris disks (Rout set to 8*Rc if Rout==0)
+  1.125                   flaring exponent, unused for envelope
+  -0.5  0.0               surface density exponent (or -gamma for tappered-edge disk or volume density for envelope), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)
+
+#Grain properties
+  3  Number of species
+  Mie  3 1  0.0  1.0  0.9 Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+    Draine_Si_sUV.dat  1.0  Optical indices file, volume fraction
+    Draine_Si_sUV.dat  2.0  Optical indices file, volume fraction
+    Draine_Si_sUV.dat  3.0  Optical indices file, volume fraction
+  3                       Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.03  1000.0 3.5 100    amin, amax [mum], aexp, n_grains (log distribution)
+
+  Mie  1 2  0.0  1.0  0.9 Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  Draine_Si_sUV.dat  1.0  Optical indices file, volume fraction
+  1                       Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.03  1000.0 3.5 100    amin, amax [mum], aexp, n_grains (log distribution)
+
+  Mie  1 2  0.0  1.0  0.9 Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  Draine_Si_sUV.dat  1.0  Optical indices file, volume fraction
+  1                       Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.03  1000.0 3.5 100    amin, amax [mum], aexp, n_grains (log distribution)
+
+#Molecular RT settings
+  T T T 15.               lpop, laccurate_pop, LTE, profile width (km.s^-1)
+  0.2                     v_turb (delta)
+  1                       nmol
+  co@xpol.dat 6           molecular data filename, level_max
+  1.0 20                  vmax (km.s^-1), n_speed
+  T 1.e-6 abundance.fits.gz   cst molecule abundance ?, abundance, abundance file
+  T  3                    ray tracing ?,  number of lines in ray-tracing
+  1 2 3                   transition numbers
+
+#Star properties
+  1 Number of stars
+  4000.0    2.0    1.0    0.0    0.0    0.0  T Temp, radius (solar radius),M (solar mass),x,y,z (AU), is a blackbody?
+  lte4000-3.5.NextGen.fits.gz
+  0.0    2.2  fUV, slope_fUV

--- a/tests/corpus/ref3.0_switch_bools.para
+++ b/tests/corpus/ref3.0_switch_bools.para
@@ -1,0 +1,78 @@
+3.0                      mcfost version
+
+#Number of photon packages
+  1.28e5                  nbr_photons_eq_th  : T computation
+  1.28e3                  nbr_photons_lambda : SED computation
+  1.28e7                  nbr_photons_image  : images computation
+
+#Wavelength
+  50  0.1 3000.0          n_lambda, lambda_min, lambda_max [mum] Do not change this line unless you know what you are doing
+  T F F                   compute temperature?, compute sed?, use default wavelength grid for output ?
+  IMLup.lambda            wavelength file (if previous parameter is F)
+  T F                     separation of different contributions?, stokes parameters?
+
+#Grid geometry and size
+  1                       1 = cylindrical, 2 = spherical, 3 = Voronoi tesselation (this is in beta, please ask Christophe)
+  100 70 1 20             n_rad (log distribution), nz (or n_theta), n_az, n_rad_in
+
+#Maps
+  101 101 700.            grid (nx,ny), size [AU]
+  45.  45.  1  T          RT: imin, imax, n_incl, centered ?
+  0    0.   1             RT: az_min, az_max, n_az angles
+  140.0                   distance (pc)
+  0.                      disk PA
+
+#Scattering method
+  0                       0=auto, 1=grain prop, 2=cell prop
+  1                       1=Mie, 2=hg (2 implies the loss of polarizarion)
+
+#Symetries
+  F                       image symmetry
+  F                       central symmetry
+  F                       axial symmetry (important only if N_phi > 1)
+
+#Disk physics
+  0     0.50  1.0         dust_settling (0=no settling, 1=parametric, 2=Dubrulle, 3=Fromang), exp_strat, a_strat (for parametric settling)
+  T                       dust radial migration
+  F                       sublimate dust
+  T                       hydostatic equilibrium
+  T  1e-5                 viscous heating, alpha_viscosity
+
+#Number of zones : 1 zone = 1 density structure + corresponding grain properties
+  1
+
+#Density structure
+  1                       zone type : 1 = disk, 2 = tappered-edge disk, 3 = envelope, 4 = debris disk, 5 = wall
+  1.e-3    100.           dust mass,  gas-to-dust mass ratio
+  10.  100.0  2           scale height, reference radius (AU), unused for envelope, vertical profile exponent (only for debris disk)
+  1.0  0.0    300.  100.  Rin, edge, Rout, Rc (AU) Rc is only used for tappered-edge & debris disks (Rout set to 8*Rc if Rout==0)
+  1.125                   flaring exponent, unused for envelope
+  -0.5  0.0               surface density exponent (or -gamma for tappered-edge disk or volume density for envelope), usually < 0, -gamma_exp (or alpha_in & alpha_out for debris disk)
+
+#Grain properties
+  1  Number of species
+  Mie  1 2  0.0  1.0  0.9 Grain type (Mie or DHS), N_components, mixing rule (1 = EMT or 2 = coating),  porosity, mass fraction, Vmax (for DHS)
+  Draine_Si_sUV.dat  1.0  Optical indices file, volume fraction
+  1                       Heating method : 1 = RE + LTE, 2 = RE + NLTE, 3 = NRE
+  0.03  1000.0 3.5 100    amin, amax [mum], aexp, n_grains (log distribution)
+
+#Molecular RT settings
+  F F F 15.               lpop, laccurate_pop, LTE, profile width (km.s^-1)
+  0.2                     v_turb (delta)
+  1                       nmol
+  co@xpol.dat 6           molecular data filename, level_max
+  1.0 20                  vmax (km.s^-1), n_speed
+  T 1.e-6 abundance.fits.gz   cst molecule abundance ?, abundance, abundance file
+  F  3                    ray tracing ?,  number of lines in ray-tracing
+  1 2 3                   transition numbers
+
+#Star properties
+  1 Number of stars
+  4000.0    2.0    1.0    0.0    0.0    0.0  F Temp, radius (solar radius),M (solar mass),x,y,z (AU), is a blackbody?
+  lte4000-3.5.NextGen.fits.gz
+  0.0    2.2  fUV, slope_fUV
+
+
+# this is a dummy copy of ref3.0.para where all booleans are inverted, except for 
+# - "compute temperature", otherwise mcfost has nothing to do and we can't validate the file
+# - "sublimate dust" because mcfost exits with an error (first cell is in diffusion zone)

--- a/tests/test_io_params.py
+++ b/tests/test_io_params.py
@@ -1,21 +1,23 @@
 from pathlib import Path
 import os
 
+import pytest
 from pymcfost import Params
 
 test_dir = Path(__file__).parent
 
+output_dir = test_dir / "artifacts"
+input_dir = test_dir / "corpus"
+corpus = list(input_dir.glob("*.para"))
 
-def test_io_copy():
-    """Read a parafile, write it elsewhere and attempt to read the copy
-    Goal : check that the copy is still valid as an input
-    """
-    input_dir = test_dir / "corpus"
-    output_dir = test_dir / "artifacts"
+
+@pytest.mark.parametrize("parafile", corpus)
+def test_io_copy(parafile):
+    """Read a valid .para file, check that it can still be read and written with no data corruption"""
     os.makedirs(output_dir, exist_ok=True)
-    for parafile in input_dir.glob("*.para"):
-        p = Params(str(parafile))
+    p1 = Params(str(parafile))
+    output_file = str(output_dir / "_".join(["copy", parafile.name]))
+    p1.writeto(output_file)
+    p2 = Params(output_file)
 
-        output_file = str(output_dir / "_".join(["copy", parafile.name]))
-        p.writeto(output_file)
-        p2 = Params(output_file)
+    assert str(p1) == str(p2)

--- a/tests/test_io_params.py
+++ b/tests/test_io_params.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import os
+
+from pymcfost import Params
+
+test_dir = Path(__file__).parent
+
+
+def test_io_copy():
+    """Read a parafile, write it elsewhere and attempt to read the copy
+    Goal : check that the copy is still valid as an input
+    """
+    input_dir = test_dir / "corpus"
+    output_dir = test_dir / "artifacts"
+    os.makedirs(output_dir, exist_ok=True)
+    for parafile in input_dir.glob("*.para"):
+        p = Params(str(parafile))
+
+        output_file = str(output_dir / "_".join(["copy", parafile.name]))
+        p.writeto(output_file)
+        p2 = Params(output_file)

--- a/tests/test_io_params.py
+++ b/tests/test_io_params.py
@@ -28,3 +28,20 @@ def test_io_copy(parafile):
     assert s3 == s1
     assert s2 == s1
 
+
+@pytest.mark.parametrize(
+    "parafile,expected",
+    [
+        ("ref3.0.para", (False, True, True, True)),
+        ("ref3.0_switch_bools.para", (True, False, False, False)),
+    ],
+)
+def test_bool_parsing(parafile, expected):
+    p = Params(input_dir / parafile)
+    result = (
+        p.simu.radial_migration,
+        p.simu.image_symmetry,
+        p.mol.compute_pop,  # lpop
+        p.stars[0].is_bb,
+    )
+    assert result == expected

--- a/tests/test_io_params.py
+++ b/tests/test_io_params.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+from copy import copy
 
 import pytest
 from pymcfost import Params
@@ -16,8 +17,14 @@ def test_io_copy(parafile):
     """Read a valid .para file, check that it can still be read and written with no data corruption"""
     os.makedirs(output_dir, exist_ok=True)
     p1 = Params(str(parafile))
+    s1 = copy(str(p1))
+
     output_file = str(output_dir / "_".join(["copy", parafile.name]))
     p1.writeto(output_file)
     p2 = Params(output_file)
+    s2 = str(p2)
 
-    assert str(p1) == str(p2)
+    s3 = str(p1)
+    assert s3 == s1
+    assert s2 == s1
+

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,13 @@
+import pytest
+from pymcfost.parameters import _word_to_bool
+
+
+true_strings = ["True", ".True.", "TRUE", ".TRUE.", "true", ".true.", "t", ".t.", "T", ".T."]
+@pytest.mark.parametrize("string", true_strings)
+def test_read_true_string(string):
+    assert _word_to_bool(string)
+
+false_strings = ["False", ".False.", "FALSE", ".FALSE.", "false", ".false.", "f", ".f.", "F", ".F."]
+@pytest.mark.parametrize("string", false_strings)
+def test_read_false_string(string):
+    assert not _word_to_bool(string)


### PR DESCRIPTION
I noticed the way `pymcfost.Params._read()` parsed boolean parameters was somewhat inconsistent and actually broken for some parameters (where a character would be compared to a `"True"` str to determine a boolean value, forcing the result to `False` whatever the character was). I propose a unified way to read those parameters from file, with an internal function `_word_to_bool()`. I also add a test file to easily check the function against all practical use cases.

edit : #15 exposes the bug by adding a test. This is now rebased on top of it and fixes the issue. 