### PR TITLE
added mcfost.plot_wake function to overplot planet wakes on observational images

### DIFF
--- a/pymcfost/__init__.py
+++ b/pymcfost/__init__.py
@@ -9,3 +9,4 @@ from .fargo2mcfost import *
 from .pluto2mcfost import *
 from .CASA_simdata import *
 from .run import *
+from .wake import *

--- a/pymcfost/utils.py
+++ b/pymcfost/utils.py
@@ -308,8 +308,34 @@ def _rotate_splash_axes(xyz, anglex, angley, anglez):
 
     return np.array([x,y,z])
 
+def rotate_vec(u,v,angle):
+    '''
+      rotate a vector (u) around an axis defined by another vector (v)
+      by an angle (theta) using the Rodrigues rotation formula
+    '''
+    k = v/np.sqrt(np.inner(v,v))
+    w = np.cross(k,u)
+    k_dot_u = np.inner(k,u)
+    for i,uval in enumerate(u):
+        u[i] = u[i]*np.cos(angle) + w[i]*np.sin(angle) + k[i]*k_dot_u*(1.-np.cos(angle))
+    return u
 
+def rotate_coords(x,y,z,inc,PA):
+    '''
+       rotate x,y,z coordinates into the observational plane
+    '''
+    k = [-np.sin(PA), np.cos(PA), 0.]
+    xvec = [x,y,z]
+    xrot = rotate_vec(xvec,k,inc)
+    return xrot[0],xrot[1],xrot[2]
 
+def rotate_to_obs_plane(x,y,inc,PA):
+    '''
+       same as rotate_coords but takes 2D x,y as arrays
+    '''
+    for i,xx in enumerate(x):    # this can probably be done more efficiently
+        x[i],y[i],dum = rotate_coords(x[i],y[i],0.,inc,PA)
+    return x,y
 
 def planet_position(model, i_planet, i_star, ):
     '''

--- a/pymcfost/wake.py
+++ b/pymcfost/wake.py
@@ -1,0 +1,51 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from .utils import rotate_coords,rotate_to_obs_plane
+
+def get_wake_cartesian(rp,phip,npts,rmin,rmax,HonR,q):
+    '''
+       planet wake formula from Rafikov (2002)
+    '''
+    rplot = np.linspace(rmin,rmax,npts)
+    rr = rplot/rp
+    phi = phip + np.sign(rmax-rmin)*(1./HonR)*((rr**(q-0.5))/(q-0.5) \
+                          - (rr**(q+1.))/(q+1.) \
+                          - 3./((2.*q-1.)*(q+1.)))
+    xx = rplot*np.cos(phi)
+    yy = rplot*np.sin(phi)
+    return xx,yy
+
+def plot_wake(xy_obs,inc,PA,HonR,q):
+    '''
+       plot planet wake
+       and rotate to the observational viewpoint
+    '''
+    inc = np.deg2rad(inc)
+    PA = np.deg2rad(PA)
+
+    # we give planet location in the observational plane
+    # bad attempt to provide the location in the rotated plane
+    # by a simple linear scaling (does not get the angle correct)
+    x_scale, y_scale, dum = rotate_coords(xy_obs[0],xy_obs[1],0.,inc,PA)
+    x_p = xy_obs[0]*(xy_obs[0]/x_scale)
+    y_p = xy_obs[1]*(xy_obs[1]/y_scale)
+
+    # planet location in the unrotated plane
+    rp = np.sqrt(x_p**2 + y_p**2)
+    phip = np.arctan2(y_p,x_p)
+    print("rp = ",rp," phi planet = ",phip*180./np.pi)
+
+    # radial range over which to plot the wake
+    rmin = 1.e-3
+    rmax = 3.*rp
+    npts = 1000
+
+    # outer wake
+    xx,yy = get_wake_cartesian(rp,phip,npts,rp,rmax,HonR,q)
+    xp,yp = rotate_to_obs_plane(xx,yy,inc,PA)
+    plt.plot(xx,yy,color='black')
+
+    # inner wake
+    xx,yy = get_wake_cartesian(rp,phip,npts,rp,rmin,HonR,q)
+    xp,yp = rotate_to_obs_plane(xx,yy,inc,PA)
+    plt.plot(xx,yy,color='black')


### PR DESCRIPTION
example:

p_loc = [-0.6, 0.15]   # planet location in observational coordinates
mcfost.plot_wake(p_loc,48.,52.,HonR=0.07,q=0.31)

produces:

![image](https://user-images.githubusercontent.com/12252103/120759633-8d18bc80-c556-11eb-8fae-d37a6c09da0e.png)

the only thing that is a bit hacked is the reverse rotation of the planet coordinates specified in the observational plane back into the unrotated plane. The wake itself is rotated into the observational plane just fine. 

I figured the routines are better contributed to pymcfost than lying around on my laptop/another git repo.