### PR TITLE
Changed import warnings to use UserWarnings class so that they may be suppressed

### DIFF
--- a/pymcfost/SED.py
+++ b/pymcfost/SED.py
@@ -1,4 +1,4 @@
-import os
+import os, warnings
 import astropy.io.fits as fits
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
@@ -7,7 +7,7 @@ import numpy as np
 try:
     import mpl_scatter_density
 except ImportError:
-    print('WARNING: mpl_scatter_density is not present')
+    warnings.warn("mpl_scatter_density is not present", UserWarning)
 
 from .parameters import Params, find_parameter_file
 from .disc_structure import _plot_cutz, check_grid

--- a/pymcfost/line.py
+++ b/pymcfost/line.py
@@ -1,4 +1,4 @@
-import os
+import os, warnings
 import astropy.io.fits as fits
 from astropy.convolution import Gaussian2DKernel, convolve_fft, convolve
 import matplotlib.colors as colors
@@ -12,7 +12,7 @@ from scipy.ndimage import convolve1d
 try:
     import progressbar
 except ImportError:
-    print('WARNING: progressbar is not present')
+    warnings.warn("progressbar is not present", UserWarning)
 
 from .parameters import Params, find_parameter_file
 from .utils import FWHM_to_sigma, default_cmap, Wm2_to_Tb, Jy_to_Tb,  Wm2_to_Jy, add_colorbar


### PR DESCRIPTION
Previous behaviour used a print statement to warn users that the packages mpl_scatter_density and progress bar are not present. This creates the situation that for codes that import pymcfost but do not need these packages, there is a print statement that cannot be suppressed using stdout. 

The new behaviour uses the warnings package as is standard for python, and uses a UserWarning so that the current behaviour is maintained, in that by default the warning is printed to console. This could be changed to an ImportWarning, but by default it will not be shown to the user unless they are in development mode. 

Now codes that rely on pymcfost do not need to have the warnings printed as they can use the warnings package to ignore them simply by ignoring UserWarning instances, e.g.
```
warnings.filterwarnings("ignore", category=UserWarning)
from pymcfost.parameters import Params
warnings.filterwarnings("default")
```