### PR TITLE
User can optionally specify name of lines file

### DIFF
--- a/pymcfost/line.py
+++ b/pymcfost/line.py
@@ -23,8 +23,8 @@ class Line:
 
     _line_file = "lines.fits.gz"
 
-    def __init__(self, dir=None, **kwargs):
-
+    def __init__(self, dir=None, line_file=None, **kwargs):
+        
         # Correct path if needed
         dir = os.path.normpath(os.path.expanduser(dir))
         self.dir = dir
@@ -34,6 +34,10 @@ class Line:
 
         # Read parameter file
         self.P = Params(para_file)
+        
+        # If user specified line_file, overwrite the default
+        if line_file is not None:
+            self._line_file = line_file
 
         # Read model results
         self._read(**kwargs)


### PR DESCRIPTION
Added a very simple change to allow the user to specify the name of the lines file instead of assuming that it is `lines.fits.gz`.

Added optional argument to `pymcfost.Line.__init__` called `line_file` which just allows the user to overwrite `Line._line_file` for a particular instantiation of the class. Default value of `line_file` is `None`, which retains original behaviour. `dir` must still be specified by the user even if they specify `line_file` because we still need to know where to look for the `.para` file.